### PR TITLE
Drop support for CacheDigests

### DIFF
--- a/lib/curlybars/railtie.rb
+++ b/lib/curlybars/railtie.rb
@@ -6,12 +6,11 @@ module Curlybars
   class Railtie < Rails::Railtie
     initializer 'curlybars.initialize_template_handler' do
       ActionView::Template.register_template_handler(:hbs, Curlybars::TemplateHandler)
+      ActionView::DependencyTracker.register_tracker(:hbs, Curlybars::DependencyTracker)
     end
 
     initializer 'curlybars.set_cache' do
       Curlybars.cache = Rails.cache
     end
-
-    ActionView::DependencyTracker.register_tracker :hbs, Curlybars::DependencyTracker
   end
 end

--- a/lib/curlybars/railtie.rb
+++ b/lib/curlybars/railtie.rb
@@ -1,5 +1,6 @@
 require 'curlybars/template_handler'
 require 'curlybars/dependency_tracker'
+require 'action_view/dependency_tracker'
 
 module Curlybars
   class Railtie < Rails::Railtie
@@ -11,12 +12,6 @@ module Curlybars
       Curlybars.cache = Rails.cache
     end
 
-    if defined?(CacheDigests::DependencyTracker)
-      CacheDigests::DependencyTracker.register_tracker :hbs, Curlybars::DependencyTracker
-    end
-
-    if defined?(ActionView::DependencyTracker)
-      ActionView::DependencyTracker.register_tracker :hbs, Curlybars::DependencyTracker
-    end
+    ActionView::DependencyTracker.register_tracker :hbs, Curlybars::DependencyTracker
   end
 end


### PR DESCRIPTION
CacheDigests was a thing you used with Rails < 4. This gem will only bundle with Rails >= 4.