### PR TITLE
Disallow helpers in conditionals

### DIFF
--- a/lib/curlybars/node/if_else.rb
+++ b/lib/curlybars/node/if_else.rb
@@ -15,7 +15,7 @@ module Curlybars
 
       def validate(branches)
         [
-          expression.validate(branches),
+          expression.validate(branches, check_type: :not_helper),
           if_template.validate(branches),
           else_template.validate(branches)
         ]

--- a/lib/curlybars/node/path.rb
+++ b/lib/curlybars/node/path.rb
@@ -127,6 +127,10 @@ module Curlybars
           return if helper?(branches)
           message = "`#{path}` cannot resolve to a helper"
           raise Curlybars::Error::Validate.new('not_a_helper', message, position)
+        when :not_helper
+          return unless helper?(branches)
+          message = "`#{path}` resolves to a helper"
+          raise Curlybars::Error::Validate.new('is_a_helper', message, position)
         when :anything
         else
           raise "invalid type `#{check_type}`"

--- a/lib/curlybars/node/unless_else.rb
+++ b/lib/curlybars/node/unless_else.rb
@@ -15,7 +15,7 @@ module Curlybars
 
       def validate(branches)
         [
-          expression.validate(branches),
+          expression.validate(branches, check_type: :not_helper),
           unless_template.validate(branches),
           else_template.validate(branches)
         ]

--- a/spec/integration/node/if_spec.rb
+++ b/spec/integration/node/if_spec.rb
@@ -139,5 +139,17 @@ describe "{{#if}}...{{/if}}" do
 
       expect(errors).not_to be_empty
     end
+
+    it "validates with errors the helper as condition" do
+      dependency_tree = { helper: :helper }
+
+      source = <<-HBS
+        {{#if helper}}{{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).not_to be_empty
+    end
   end
 end

--- a/spec/integration/node/unless_else_spec.rb
+++ b/spec/integration/node/unless_else_spec.rb
@@ -96,6 +96,18 @@ describe "{{#unless}}...{{else}}...{{/unless}}" do
       expect(errors).not_to be_empty
     end
 
+    it "validates with errors the helper as condition" do
+      dependency_tree = { helper: :helper }
+
+      source = <<-HBS
+        {{#unless helper}}{{/unless}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).not_to be_empty
+    end
+
     it "validates with errors the nested unless_template" do
       dependency_tree = { condition: nil }
 


### PR DESCRIPTION
The following snippet passes the validation (assume that `excerpt` is a helper):

`{{#if excerpt}}{{/if}}`

Helpers always have parameters so their use in conditionals make only sense when Handlebar subexpressions are supported, for example:

`{{#if (excerpt "does_not_matter" characters=0)}}{{/if}}`

(still theoretical example, evaluates to false always, naturally not useful)

Curlybars doesn't currently support subexpressions, therefore disallowing helpers in conditionals. 

@zendesk/delta
