### PR TITLE
Use default config for RSpec/ReturnFromStub

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,10 +73,6 @@ Layout/IndentHash:
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
-# Checks for consistent style of stub's return setting.
-RSpec/ReturnFromStub:
-  EnforcedStyle: block
-
 # Use alias instead of alias_method.
 Style/Alias:
   EnforcedStyle: prefer_alias_method

--- a/spec/curlybars/rendering_support_spec.rb
+++ b/spec/curlybars/rendering_support_spec.rb
@@ -71,7 +71,7 @@ describe Curlybars::RenderingSupport do
   describe "#path" do
     it "returns the method in the current context" do
       allow_all_methods(presenter)
-      allow(presenter).to receive(:method) { :method }
+      allow(presenter).to receive(:method).and_return(:method)
 
       expect(rendering.path('method', rendering.position(0, 1))).to eq :method
     end
@@ -79,7 +79,7 @@ describe Curlybars::RenderingSupport do
     it "returns the sub presenter method in the current context" do
       sub = double(:sub_presenter)
       allow_all_methods(sub)
-      allow(sub).to receive(:method) { :method }
+      allow(sub).to receive(:method).and_return(:method)
 
       allow_all_methods(presenter)
       allow(presenter).to receive(:sub) { sub }
@@ -100,7 +100,7 @@ describe Curlybars::RenderingSupport do
 
     it "raises an exception when the method is not allowed" do
       disallow_all_methods(presenter)
-      allow(presenter).to receive(:forbidden_method) { :forbidden_method }
+      allow(presenter).to receive(:forbidden_method).and_return(:forbidden_method)
 
       expect do
         rendering.path('forbidden_method', rendering.position(0, 1))
@@ -109,7 +109,7 @@ describe Curlybars::RenderingSupport do
 
     it "exposes the unallowed method in the exception payload" do
       disallow_all_methods(presenter)
-      allow(presenter).to receive(:forbidden_method) { :forbidden_method }
+      allow(presenter).to receive(:forbidden_method).and_return(:forbidden_method)
 
       begin
         rendering.path('forbidden_method', rendering.position(0, 1))
@@ -130,10 +130,10 @@ describe Curlybars::RenderingSupport do
     it "refers to the second to last presenter in the stack when using `../`" do
       sub = double(:sub_presenter)
       allow_all_methods(sub)
-      allow(sub).to receive(:method) { :sub_method }
+      allow(sub).to receive(:method).and_return(:sub_method)
 
       allow_all_methods(presenter)
-      allow(presenter).to receive(:method) { :root_method }
+      allow(presenter).to receive(:method).and_return(:root_method)
 
       contexts.push(sub)
 
@@ -143,14 +143,14 @@ describe Curlybars::RenderingSupport do
     it "refers to the third to last presenter in the stack when using `../../`" do
       sub_sub = double(:sub_presenter)
       allow_all_methods(sub_sub)
-      allow(sub_sub).to receive(:method) { :sub_sub_method }
+      allow(sub_sub).to receive(:method).and_return(:sub_sub_method)
 
       sub = double(:sub_presenter)
       allow_all_methods(sub)
-      allow(sub).to receive(:method) { :sub_method }
+      allow(sub).to receive(:method).and_return(:sub_method)
 
       allow_all_methods(presenter)
-      allow(presenter).to receive(:method) { :root_method }
+      allow(presenter).to receive(:method).and_return(:root_method)
 
       contexts.push(sub)
       contexts.push(sub_sub)
@@ -160,7 +160,7 @@ describe Curlybars::RenderingSupport do
 
     it "returns a method that returns nil, if nil is returned from any method in the chain (except the latter)" do
       allow_all_methods(presenter)
-      allow(presenter).to receive(:returns_nil) { nil }
+      allow(presenter).to receive(:returns_nil).and_return(nil)
 
       outcome = rendering.path('returns_nil.another_method', rendering.position(0, 1)).call
       expect(outcome).to be_nil
@@ -417,10 +417,10 @@ describe Curlybars::RenderingSupport do
   private
 
   def allow_all_methods(presenter)
-    allow(presenter).to receive(:allows_method?) { true }
+    allow(presenter).to receive(:allows_method?).and_return(true)
   end
 
   def disallow_all_methods(presenter)
-    allow(presenter).to receive(:allows_method?) { false }
+    allow(presenter).to receive(:allows_method?).and_return(false)
   end
 end

--- a/spec/curlybars/safe_buffer_spec.rb
+++ b/spec/curlybars/safe_buffer_spec.rb
@@ -17,7 +17,7 @@ describe Curlybars::SafeBuffer do
 
   describe "#concat" do
     it "accepts when (buffer length + the existing output lenght) <= output_limit" do
-      allow(configuration).to receive(:output_limit) { 10 }
+      allow(configuration).to receive(:output_limit).and_return(10)
 
       buffer = Curlybars::SafeBuffer.new('*' * 5)
 
@@ -27,7 +27,7 @@ describe Curlybars::SafeBuffer do
     end
 
     it "raises when (buffer length + the existing output lenght) > output_limit" do
-      allow(configuration).to receive(:output_limit) { 10 }
+      allow(configuration).to receive(:output_limit).and_return(10)
       buffer = Curlybars::SafeBuffer.new('*' * 10)
 
       expect do
@@ -36,7 +36,7 @@ describe Curlybars::SafeBuffer do
     end
 
     it "raises when buffer length > output_limit" do
-      allow(configuration).to receive(:output_limit) { 10 }
+      allow(configuration).to receive(:output_limit).and_return(10)
 
       expect do
         Curlybars::SafeBuffer.new.concat('*' * 11)

--- a/spec/curlybars/template_handler_spec.rb
+++ b/spec/curlybars/template_handler_spec.rb
@@ -113,44 +113,44 @@ describe Curlybars::TemplateHandler do
   end
 
   it "passes in the presenter context to the presenter class" do
-    allow(context).to receive(:bar) { "BAR" }
-    allow(template).to receive(:source) { "{{bar}}" }
+    allow(context).to receive(:bar).and_return("BAR")
+    allow(template).to receive(:source).and_return("{{bar}}")
     expect(output).to eq("BAR")
   end
 
   it "fails if there's no matching presenter class" do
-    allow(template).to receive(:virtual_path) { "missing" }
-    allow(template).to receive(:source) { " FOO " }
+    allow(template).to receive(:virtual_path).and_return("missing")
+    allow(template).to receive(:source).and_return(" FOO ")
     expect { output }.to raise_exception(Curlybars::Error::Presenter::NotFound)
   end
 
   it "allows calling public methods on the presenter" do
-    allow(template).to receive(:source) { "{{foo}}" }
+    allow(template).to receive(:source).and_return("{{foo}}")
     expect(output).to eq("FOO")
   end
 
   it "marks its output as HTML safe" do
-    allow(template).to receive(:source) { "{{foo}}" }
+    allow(template).to receive(:source).and_return("{{foo}}")
     expect(output).to be_html_safe
   end
 
   it "calls the #setup! method before rendering the view" do
-    allow(template).to receive(:source) { "{{foo}}" }
+    allow(template).to receive(:source).and_return("{{foo}}")
     output
     expect(context.content_for(:foo)).to eq("bar")
   end
 
   describe "caching" do
     before do
-      allow(template).to receive(:source) { "{{bar}}" }
-      allow(context).to receive(:bar) { "BAR" }
+      allow(template).to receive(:source).and_return("{{bar}}")
+      allow(context).to receive(:bar).and_return("BAR")
     end
 
     it "caches the result with the #cache_key from the presenter" do
       context.assigns[:cache_key] = "x"
       expect(output).to eq("BAR")
 
-      allow(context).to receive(:bar) { "BAZ" }
+      allow(context).to receive(:bar).and_return("BAZ")
       expect(output).to eq("BAR")
 
       context.assigns[:cache_key] = "y"
@@ -161,7 +161,7 @@ describe Curlybars::TemplateHandler do
       context.assigns[:cache_key] = nil
       expect(output).to eq("BAR")
 
-      allow(context).to receive(:bar) { "BAZ" }
+      allow(context).to receive(:bar).and_return("BAZ")
       expect(output).to eq("BAZ")
     end
 
@@ -169,13 +169,13 @@ describe Curlybars::TemplateHandler do
       # Make sure caching is enabled
       context.assigns[:cache_key] = "x"
 
-      allow(presenter_class).to receive(:cache_key) { "foo" }
+      allow(presenter_class).to receive(:cache_key).and_return("foo")
 
       expect(output).to eq("BAR")
 
-      allow(presenter_class).to receive(:cache_key) { "bar" }
+      allow(presenter_class).to receive(:cache_key).and_return("bar")
 
-      allow(context).to receive(:bar) { "FOOBAR" }
+      allow(context).to receive(:bar).and_return("FOOBAR")
       expect(output).to eq("FOOBAR")
     end
 
@@ -185,7 +185,7 @@ describe Curlybars::TemplateHandler do
 
       expect(output).to eq("BAR")
 
-      allow(context).to receive(:bar) { "FOO" }
+      allow(context).to receive(:bar).and_return("FOO")
 
       # Cached fragment has not yet expired.
       context.advance_clock(41)
@@ -202,7 +202,7 @@ describe Curlybars::TemplateHandler do
 
       expect(output).to eq("BAR")
 
-      allow(context).to receive(:bar) { "FOO" }
+      allow(context).to receive(:bar).and_return("FOO")
 
       # Cached fragment has not yet expired.
       context.advance_clock(41)

--- a/spec/integration/node/block_helper_else_spec.rb
+++ b/spec/integration/node/block_helper_else_spec.rb
@@ -233,7 +233,7 @@ describe "{{#helper arg1 arg2 ... key=value ...}}...<{{else}}>...{{/helper}}" do
     let(:presenter_class) { double(:presenter_class) }
 
     it "without errors when global helper" do
-      allow(Curlybars.configuration).to receive(:global_helpers_provider_classes) { [IntegrationTest::GlobalHelperProvider] }
+      allow(Curlybars.configuration).to receive(:global_helpers_provider_classes).and_return([IntegrationTest::GlobalHelperProvider])
 
       dependency_tree = {}
 

--- a/spec/integration/node/each_else_spec.rb
+++ b/spec/integration/node/each_else_spec.rb
@@ -6,7 +6,7 @@ describe "{{#each collection}}...{{else}}...{{/each}}" do
     let(:presenter) { IntegrationTest::Presenter.new(double("view_context"), post: post) }
 
     it "uses each_template when collection is not empty" do
-      allow(presenter).to receive(:allows_method?).with(:non_empty_collection) { true }
+      allow(presenter).to receive(:allows_method?).with(:non_empty_collection).and_return(true)
       allow(presenter).to receive(:non_empty_collection) { [presenter] }
 
       template = Curlybars.compile(<<-HBS)
@@ -23,8 +23,8 @@ describe "{{#each collection}}...{{else}}...{{/each}}" do
     end
 
     it "uses else_template when collection is empty" do
-      allow(presenter).to receive(:allows_method?).with(:empty_collection) { true }
-      allow(presenter).to receive(:empty_collection) { [] }
+      allow(presenter).to receive(:allows_method?).with(:empty_collection).and_return(true)
+      allow(presenter).to receive(:empty_collection).and_return([])
 
       template = Curlybars.compile(<<-HBS)
         {{#each empty_collection}}
@@ -51,7 +51,7 @@ describe "{{#each collection}}...{{else}}...{{/each}}" do
       a_path_presenter = path_presenter_class.new(nil, path: 'a_path')
       another_path_presenter = path_presenter_class.new(nil, path: 'another_path')
 
-      allow(presenter).to receive(:allows_method?).with(:non_empty_collection) { true }
+      allow(presenter).to receive(:allows_method?).with(:non_empty_collection).and_return(true)
       allow(presenter).to receive(:non_empty_collection) { [a_path_presenter, another_path_presenter] }
 
       template = Curlybars.compile(<<-HBS)
@@ -69,8 +69,8 @@ describe "{{#each collection}}...{{else}}...{{/each}}" do
     end
 
     it "allows empty each_template" do
-      allow(presenter).to receive(:allows_method?).with(:empty_collection) { true }
-      allow(presenter).to receive(:empty_collection) { [] }
+      allow(presenter).to receive(:allows_method?).with(:empty_collection).and_return(true)
+      allow(presenter).to receive(:empty_collection).and_return([])
 
       template = Curlybars.compile(<<-HBS)
         {{#each empty_collection}}{{else}}
@@ -84,7 +84,7 @@ describe "{{#each collection}}...{{else}}...{{/each}}" do
     end
 
     it "allows empty else_template" do
-      allow(presenter).to receive(:allows_method?).with(:non_empty_collection) { true }
+      allow(presenter).to receive(:allows_method?).with(:non_empty_collection).and_return(true)
       allow(presenter).to receive(:non_empty_collection) { [presenter] }
 
       template = Curlybars.compile(<<-HBS)
@@ -99,7 +99,7 @@ describe "{{#each collection}}...{{else}}...{{/each}}" do
     end
 
     it "allows empty each_template and else_template" do
-      allow(presenter).to receive(:allows_method?).with(:non_empty_collection) { true }
+      allow(presenter).to receive(:allows_method?).with(:non_empty_collection).and_return(true)
       allow(presenter).to receive(:non_empty_collection) { [presenter] }
 
       template = Curlybars.compile(<<-HBS)
@@ -124,8 +124,8 @@ describe "{{#each collection}}...{{else}}...{{/each}}" do
     end
 
     it "raises an error if the context is not an array-like object" do
-      allow(IntegrationTest::Presenter).to receive(:allows_method?).with(:not_a_collection) { true }
-      allow(presenter).to receive(:not_a_collection) { "string" }
+      allow(IntegrationTest::Presenter).to receive(:allows_method?).with(:not_a_collection).and_return(true)
+      allow(presenter).to receive(:not_a_collection).and_return("string")
 
       template = Curlybars.compile(<<-HBS)
         {{#each not_a_collection}}{{else}}{{/each}}
@@ -137,8 +137,8 @@ describe "{{#each collection}}...{{else}}...{{/each}}" do
     end
 
     it "raises an error if the objects inside of the context array are not presenters" do
-      allow(IntegrationTest::Presenter).to receive(:allows_method?).with(:not_a_presenter_collection) { true }
-      allow(presenter).to receive(:not_a_presenter_collection) { [:an_element] }
+      allow(IntegrationTest::Presenter).to receive(:allows_method?).with(:not_a_presenter_collection).and_return(true)
+      allow(presenter).to receive(:not_a_presenter_collection).and_return([:an_element])
 
       template = Curlybars.compile(<<-HBS)
         {{#each not_a_presenter_collection}}{{else}}{{/each}}

--- a/spec/integration/node/each_spec.rb
+++ b/spec/integration/node/each_spec.rb
@@ -6,7 +6,7 @@ describe "{{#each collection}}...{{/each}}" do
     let(:presenter) { IntegrationTest::Presenter.new(double("view_context"), post: post) }
 
     it "uses each_template when collection is not empty" do
-      allow(presenter).to receive(:allows_method?).with(:non_empty_collection) { true }
+      allow(presenter).to receive(:allows_method?).with(:non_empty_collection).and_return(true)
       allow(presenter).to receive(:non_empty_collection) { [presenter] }
 
       template = Curlybars.compile(<<-HBS)
@@ -21,8 +21,8 @@ describe "{{#each collection}}...{{/each}}" do
     end
 
     it "doesn't use each_template when collection is empty" do
-      allow(presenter).to receive(:allows_method?).with(:empty_collection) { true }
-      allow(presenter).to receive(:empty_collection) { [] }
+      allow(presenter).to receive(:allows_method?).with(:empty_collection).and_return(true)
+      allow(presenter).to receive(:empty_collection).and_return([])
 
       template = Curlybars.compile(<<-HBS)
         {{#each empty_collection}}
@@ -34,7 +34,7 @@ describe "{{#each collection}}...{{/each}}" do
     end
 
     it "allows empty each_template" do
-      allow(presenter).to receive(:allows_method?).with(:non_empty_collection) { true }
+      allow(presenter).to receive(:allows_method?).with(:non_empty_collection).and_return(true)
       allow(presenter).to receive(:non_empty_collection) { [presenter] }
 
       template = Curlybars.compile(<<-HBS)
@@ -56,7 +56,7 @@ describe "{{#each collection}}...{{/each}}" do
       a_path_presenter = path_presenter_class.new(nil, path: 'a_path')
       another_path_presenter = path_presenter_class.new(nil, path: 'another_path')
 
-      allow(presenter).to receive(:allows_method?).with(:non_empty_collection) { true }
+      allow(presenter).to receive(:allows_method?).with(:non_empty_collection).and_return(true)
       allow(presenter).to receive(:non_empty_collection) { [a_path_presenter, another_path_presenter] }
 
       template = Curlybars.compile(<<-HBS)
@@ -83,7 +83,7 @@ describe "{{#each collection}}...{{/each}}" do
       a_path_presenter = path_presenter_class.new(nil, path: 'a_path')
       another_path_presenter = path_presenter_class.new(nil, path: 'another_path')
 
-      allow(presenter).to receive(:allows_method?).with(:non_empty_hash) { true }
+      allow(presenter).to receive(:allows_method?).with(:non_empty_hash).and_return(true)
       allow(presenter).to receive(:non_empty_hash) do
         { first: a_path_presenter, second: another_path_presenter }
       end
@@ -101,8 +101,8 @@ describe "{{#each collection}}...{{/each}}" do
     end
 
     it "raises an error if the context is not an array-like object" do
-      allow(presenter).to receive(:allows_method?).with(:not_a_collection) { true }
-      allow(presenter).to receive(:not_a_collection) { "string" }
+      allow(presenter).to receive(:allows_method?).with(:not_a_collection).and_return(true)
+      allow(presenter).to receive(:not_a_collection).and_return("string")
 
       template = Curlybars.compile(<<-HBS)
         {{#each not_a_collection}}{{/each}}
@@ -206,7 +206,7 @@ describe "{{#each collection}}...{{/each}}" do
       a_path_presenter = path_presenter_class.new(nil, path: 'a_path')
       another_path_presenter = path_presenter_class.new(nil, path: 'another_path')
 
-      allow(presenter).to receive(:allows_method?).with(:non_empty_hash) { true }
+      allow(presenter).to receive(:allows_method?).with(:non_empty_hash).and_return(true)
       allow(presenter).to receive(:non_empty_hash) do
         { first: a_path_presenter, second: another_path_presenter }
       end
@@ -224,8 +224,8 @@ describe "{{#each collection}}...{{/each}}" do
     end
 
     it "raises an error if the objects inside of the context array are not presenters" do
-      allow(presenter).to receive(:allows_method?).with(:not_a_presenter_collection) { true }
-      allow(presenter).to receive(:not_a_presenter_collection) { [:an_element] }
+      allow(presenter).to receive(:allows_method?).with(:not_a_presenter_collection).and_return(true)
+      allow(presenter).to receive(:not_a_presenter_collection).and_return([:an_element])
 
       template = Curlybars.compile(<<-HBS)
         {{#each not_a_presenter_collection}}{{/each}}

--- a/spec/integration/node/if_else_spec.rb
+++ b/spec/integration/node/if_else_spec.rb
@@ -6,8 +6,8 @@ describe "{{#if}}...{{else}}...{{/if}}" do
     let(:presenter) { IntegrationTest::Presenter.new(double("view_context"), post: post) }
 
     it "renders the if_template" do
-      allow(IntegrationTest::Presenter).to receive(:allows_method?).with(:return_true) { true }
-      allow(presenter).to receive(:return_true) { true }
+      allow(IntegrationTest::Presenter).to receive(:allows_method?).with(:return_true).and_return(true)
+      allow(presenter).to receive(:return_true).and_return(true)
 
       template = Curlybars.compile(<<-HBS)
         {{#if return_true}}
@@ -23,8 +23,8 @@ describe "{{#if}}...{{else}}...{{/if}}" do
     end
 
     it "renders the else_template" do
-      allow(IntegrationTest::Presenter).to receive(:allows_method?).with(:return_false) { true }
-      allow(presenter).to receive(:return_false) { false }
+      allow(IntegrationTest::Presenter).to receive(:allows_method?).with(:return_false).and_return(true)
+      allow(presenter).to receive(:return_false).and_return(false)
 
       template = Curlybars.compile(<<-HBS)
         {{#if return_false}}
@@ -40,8 +40,8 @@ describe "{{#if}}...{{else}}...{{/if}}" do
     end
 
     it "allows empty if_template" do
-      allow(IntegrationTest::Presenter).to receive(:allows_method?).with(:valid) { true }
-      allow(presenter).to receive(:valid) { false }
+      allow(IntegrationTest::Presenter).to receive(:allows_method?).with(:valid).and_return(true)
+      allow(presenter).to receive(:valid).and_return(false)
 
       template = Curlybars.compile(<<-HBS)
       {{#if valid}}{{else}}
@@ -55,8 +55,8 @@ describe "{{#if}}...{{else}}...{{/if}}" do
     end
 
     it "allows empty else_template" do
-      allow(IntegrationTest::Presenter).to receive(:allows_method?).with(:valid) { true }
-      allow(presenter).to receive(:valid) { true }
+      allow(IntegrationTest::Presenter).to receive(:allows_method?).with(:valid).and_return(true)
+      allow(presenter).to receive(:valid).and_return(true)
 
       template = Curlybars.compile(<<-HBS)
         {{#if valid}}
@@ -70,8 +70,8 @@ describe "{{#if}}...{{else}}...{{/if}}" do
     end
 
     it "allows empty if_template and else_template" do
-      allow(IntegrationTest::Presenter).to receive(:allows_method?).with(:valid) { true }
-      allow(presenter).to receive(:valid) { true }
+      allow(IntegrationTest::Presenter).to receive(:allows_method?).with(:valid).and_return(true)
+      allow(presenter).to receive(:valid).and_return(true)
 
       template = Curlybars.compile(<<-HBS)
         {{#if valid}}{{else}}{{/if}}

--- a/spec/integration/node/if_spec.rb
+++ b/spec/integration/node/if_spec.rb
@@ -6,8 +6,8 @@ describe "{{#if}}...{{/if}}" do
     let(:presenter) { IntegrationTest::Presenter.new(double("view_context"), post: post) }
 
     it "returns positive branch when condition is true" do
-      allow(presenter).to receive(:allows_method?).with(:valid) { true }
-      allow(presenter).to receive(:valid) { true }
+      allow(presenter).to receive(:allows_method?).with(:valid).and_return(true)
+      allow(presenter).to receive(:valid).and_return(true)
 
       template = Curlybars.compile(<<-HBS)
         {{#if valid}}
@@ -21,8 +21,8 @@ describe "{{#if}}...{{/if}}" do
     end
 
     it "doesn't return positive branch when condition is false" do
-      allow(presenter).to receive(:allows_method?).with(:valid) { true }
-      allow(presenter).to receive(:valid) { false }
+      allow(presenter).to receive(:allows_method?).with(:valid).and_return(true)
+      allow(presenter).to receive(:valid).and_return(false)
 
       template = Curlybars.compile(<<-HBS)
         {{#if valid}}
@@ -34,8 +34,8 @@ describe "{{#if}}...{{/if}}" do
     end
 
     it "doesn't return positive branch when condition is empty array" do
-      allow(presenter).to receive(:allows_method?).with(:collection) { true }
-      allow(presenter).to receive(:collection) { [] }
+      allow(presenter).to receive(:allows_method?).with(:collection).and_return(true)
+      allow(presenter).to receive(:collection).and_return([])
 
       template = Curlybars.compile(<<-HBS)
         {{#if collection}}
@@ -47,10 +47,10 @@ describe "{{#if}}...{{/if}}" do
     end
 
     it "works with nested `if blocks` (double positive)" do
-      allow(presenter).to receive(:allows_method?).with(:valid) { true }
-      allow(presenter).to receive(:allows_method?).with(:visible) { true }
-      allow(presenter).to receive(:valid) { true }
-      allow(presenter).to receive(:visible) { true }
+      allow(presenter).to receive(:allows_method?).with(:valid).and_return(true)
+      allow(presenter).to receive(:allows_method?).with(:visible).and_return(true)
+      allow(presenter).to receive(:valid).and_return(true)
+      allow(presenter).to receive(:visible).and_return(true)
 
       template = Curlybars.compile(<<-HBS)
         {{#if valid}}
@@ -68,10 +68,10 @@ describe "{{#if}}...{{/if}}" do
     end
 
     it "works with nested `if blocks` (positive and negative)" do
-      allow(presenter).to receive(:allows_method?).with(:valid) { true }
-      allow(presenter).to receive(:allows_method?).with(:visible) { true }
-      allow(presenter).to receive(:valid) { true }
-      allow(presenter).to receive(:visible) { false }
+      allow(presenter).to receive(:allows_method?).with(:valid).and_return(true)
+      allow(presenter).to receive(:allows_method?).with(:visible).and_return(true)
+      allow(presenter).to receive(:valid).and_return(true)
+      allow(presenter).to receive(:visible).and_return(false)
 
       template = Curlybars.compile(<<-HBS)
         {{#if valid}}
@@ -88,8 +88,8 @@ describe "{{#if}}...{{/if}}" do
     end
 
     it "allows empty if_template" do
-      allow(presenter).to receive(:allows_method?).with(:valid) { true }
-      allow(presenter).to receive(:valid) { true }
+      allow(presenter).to receive(:allows_method?).with(:valid).and_return(true)
+      allow(presenter).to receive(:valid).and_return(true)
 
       template = Curlybars.compile(<<-HBS)
         {{#if valid}}{{/if}}

--- a/spec/integration/node/unless_else_spec.rb
+++ b/spec/integration/node/unless_else_spec.rb
@@ -6,8 +6,8 @@ describe "{{#unless}}...{{else}}...{{/unless}}" do
     let(:presenter) { IntegrationTest::Presenter.new(double("view_context"), post: post) }
 
     it "renders the unless_template" do
-      allow(presenter).to receive(:allows_method?).with(:condition) { true }
-      allow(presenter).to receive(:condition) { false }
+      allow(presenter).to receive(:allows_method?).with(:condition).and_return(true)
+      allow(presenter).to receive(:condition).and_return(false)
 
       template = Curlybars.compile(<<-HBS)
         {{#unless condition}}
@@ -23,8 +23,8 @@ describe "{{#unless}}...{{else}}...{{/unless}}" do
     end
 
     it "renders the else_template" do
-      allow(presenter).to receive(:allows_method?).with(:condition) { true }
-      allow(presenter).to receive(:condition) { true }
+      allow(presenter).to receive(:allows_method?).with(:condition).and_return(true)
+      allow(presenter).to receive(:condition).and_return(true)
 
       template = Curlybars.compile(<<-HBS)
         {{#unless condition}}
@@ -40,8 +40,8 @@ describe "{{#unless}}...{{else}}...{{/unless}}" do
     end
 
     it "allows empty else_template" do
-      allow(presenter).to receive(:allows_method?).with(:valid) { true }
-      allow(presenter).to receive(:valid) { false }
+      allow(presenter).to receive(:allows_method?).with(:valid).and_return(true)
+      allow(presenter).to receive(:valid).and_return(false)
 
       template = Curlybars.compile(<<-HBS)
         {{#unless valid}}
@@ -55,8 +55,8 @@ describe "{{#unless}}...{{else}}...{{/unless}}" do
     end
 
     it "allows empty unless_template" do
-      allow(presenter).to receive(:allows_method?).with(:valid) { true }
-      allow(presenter).to receive(:valid) { true }
+      allow(presenter).to receive(:allows_method?).with(:valid).and_return(true)
+      allow(presenter).to receive(:valid).and_return(true)
 
       template = Curlybars.compile(<<-HBS)
         {{#unless valid}}{{else}}
@@ -70,8 +70,8 @@ describe "{{#unless}}...{{else}}...{{/unless}}" do
     end
 
     it "allows empty unless_template and else_template" do
-      allow(presenter).to receive(:allows_method?).with(:valid) { true }
-      allow(presenter).to receive(:valid) { false }
+      allow(presenter).to receive(:allows_method?).with(:valid).and_return(true)
+      allow(presenter).to receive(:valid).and_return(false)
 
       template = Curlybars.compile(<<-HBS)
         {{#unless valid}}{{else}}{{/unless}}

--- a/spec/integration/node/unless_spec.rb
+++ b/spec/integration/node/unless_spec.rb
@@ -6,8 +6,8 @@ describe "{{#unless}}...{{/unless}}" do
     let(:presenter) { IntegrationTest::Presenter.new(double("view_context"), post: post) }
 
     it "returns unless_template when condition is false" do
-      allow(presenter).to receive(:allows_method?).with(:condition) { true }
-      allow(presenter).to receive(:condition) { false }
+      allow(presenter).to receive(:allows_method?).with(:condition).and_return(true)
+      allow(presenter).to receive(:condition).and_return(false)
 
       template = Curlybars.compile(<<-HBS)
         {{#unless condition}}
@@ -21,8 +21,8 @@ describe "{{#unless}}...{{/unless}}" do
     end
 
     it "doesn't return unless_template when condition is true" do
-      allow(presenter).to receive(:allows_method?).with(:condition) { true }
-      allow(presenter).to receive(:condition) { true }
+      allow(presenter).to receive(:allows_method?).with(:condition).and_return(true)
+      allow(presenter).to receive(:condition).and_return(true)
 
       template = Curlybars.compile(<<-HBS)
         {{#unless condition}}
@@ -34,10 +34,10 @@ describe "{{#unless}}...{{/unless}}" do
     end
 
     it "works with nested unless blocks (double negative)" do
-      allow(presenter).to receive(:allows_method?).with(:first_condition) { true }
-      allow(presenter).to receive(:allows_method?).with(:second_condition) { true }
-      allow(presenter).to receive(:first_condition) { false }
-      allow(presenter).to receive(:second_condition) { false }
+      allow(presenter).to receive(:allows_method?).with(:first_condition).and_return(true)
+      allow(presenter).to receive(:allows_method?).with(:second_condition).and_return(true)
+      allow(presenter).to receive(:first_condition).and_return(false)
+      allow(presenter).to receive(:second_condition).and_return(false)
 
       template = Curlybars.compile(<<-HBS)
         {{#unless first_condition}}
@@ -55,8 +55,8 @@ describe "{{#unless}}...{{/unless}}" do
     end
 
     it "allows empty unless_template" do
-      allow(presenter).to receive(:allows_method?).with(:valid) { true }
-      allow(presenter).to receive(:valid) { true }
+      allow(presenter).to receive(:allows_method?).with(:valid).and_return(true)
+      allow(presenter).to receive(:valid).and_return(true)
 
       template = Curlybars.compile(<<-HBS)
         {{#unless valid}}{{/unless}}
@@ -66,10 +66,10 @@ describe "{{#unless}}...{{/unless}}" do
     end
 
     it "works with nested unless blocks (negative and positive)" do
-      allow(presenter).to receive(:allows_method?).with(:first_condition) { true }
-      allow(presenter).to receive(:allows_method?).with(:second_condition) { true }
-      allow(presenter).to receive(:first_condition) { false }
-      allow(presenter).to receive(:second_condition) { true }
+      allow(presenter).to receive(:allows_method?).with(:first_condition).and_return(true)
+      allow(presenter).to receive(:allows_method?).with(:second_condition).and_return(true)
+      allow(presenter).to receive(:first_condition).and_return(false)
+      allow(presenter).to receive(:second_condition).and_return(true)
 
       template = Curlybars.compile(<<-HBS)
         {{#unless first_condition}}


### PR DESCRIPTION
Consistently use `and_return` for static return values, and blocks for dynamic values.