### PR TITLE
Fix validation issue

### DIFF
--- a/lib/curlybars/node/literal.rb
+++ b/lib/curlybars/node/literal.rb
@@ -9,7 +9,7 @@ module Curlybars
         RUBY
       end
 
-      def validate(branches)
+      def validate(branches, check_type: :anything)
         # Nothing to validate here.
       end
 

--- a/lib/curlybars/node/variable.rb
+++ b/lib/curlybars/node/variable.rb
@@ -15,7 +15,7 @@ module Curlybars
         RUBY
       end
 
-      def validate(branches)
+      def validate(branches, check_type: :anything)
         # Nothing to validate here.
       end
 

--- a/spec/integration/node/if_else_spec.rb
+++ b/spec/integration/node/if_else_spec.rb
@@ -84,6 +84,18 @@ describe "{{#if}}...{{else}}...{{/if}}" do
   describe "#validate" do
     let(:presenter_class) { double(:presenter_class) }
 
+    it "validates without errors the literal condition" do
+      dependency_tree = {}
+
+      source = <<-HBS
+        {{#if 42}}{{else}}{{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).to be_empty
+    end
+
     it "validates with errors the condition" do
       dependency_tree = {}
 


### PR DESCRIPTION
If statement expression is validated with the `check_type: :not_helper` argument. An experession can be either `path`, `variable`, or `literal`. 

Make sure all these node types the parser allows as expressions are prepared to receive the argument.  

@zendesk/delta

