### PR TITLE
Cache `Curlybars.compile`

### DIFF
--- a/curlybars.gemspec
+++ b/curlybars.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
 
   s.add_dependency("actionpack", [">= 4.2", "< 6.0"])
+  s.add_dependency("activesupport", [">= 4.2", "< 6.0"])
   s.add_dependency("ffi")
   s.add_dependency("rltk")
 

--- a/lib/curlybars/railtie.rb
+++ b/lib/curlybars/railtie.rb
@@ -7,6 +7,10 @@ module Curlybars
       ActionView::Template.register_template_handler(:hbs, Curlybars::TemplateHandler)
     end
 
+    initializer 'curlybars.set_cache' do
+      Curlybars.cache = Rails.cache
+    end
+
     if defined?(CacheDigests::DependencyTracker)
       CacheDigests::DependencyTracker.register_tracker :hbs, Curlybars::DependencyTracker
     end


### PR DESCRIPTION
This method can take a long time to compile large templates.