### PR TITLE
Use memory_store for caching when running specs

### DIFF
--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -7,5 +7,6 @@ require "curlybars"
 
 module Dummy
   class Application < Rails::Application
+    config.cache_store = :memory_store
   end
 end


### PR DESCRIPTION
Avoid filling up local file system (spec/dummy/tmp/cache/**/Curlybars.compile/*) with cached compilations when running the specs.