### PR TITLE
Add mechanism for traversing Curlybars AST

### DIFF
--- a/lib/curlybars/visitor.rb
+++ b/lib/curlybars/visitor.rb
@@ -1,0 +1,100 @@
+require 'active_support/core_ext/string/inflections'
+
+module Curlybars
+  class Visitor
+    attr_accessor :context
+
+    def initialize(context)
+      @context = context
+    end
+
+    def accept(node)
+      visit(node)
+      context
+    end
+
+    private
+
+    def visit(node)
+      class_name = node.class.name.to_s
+      return unless class_name.start_with?('Curlybars::Node')
+
+      method_name = class_name.demodulize.underscore
+      send("visit_#{method_name}", node)
+    end
+
+    def visit_block_helper_else(node)
+      node.arguments.each { |arg| visit(arg) }
+      node.options.each { |opt| visit(opt) }
+      visit(node.helper)
+      visit(node.helper_template)
+      visit(node.else_template)
+    end
+
+    def visit_boolean(_node)
+    end
+
+    def visit_each_else(node)
+      visit(node.path)
+      visit(node.each_template)
+      visit(node.else_template)
+    end
+
+    def visit_if_else(node)
+      visit(node.expression)
+      visit(node.if_template)
+      visit(node.else_template)
+    end
+
+    def visit_item(node)
+      visit(node.item)
+    end
+
+    def visit_literal(_node)
+    end
+
+    def visit_option(node)
+      visit(node.expression)
+    end
+
+    def visit_output(node)
+      visit(node.value)
+    end
+
+    def visit_partial(node)
+      visit(node.path)
+    end
+
+    def visit_path(_node)
+    end
+
+    def visit_root(node)
+      visit(node.template)
+    end
+
+    def visit_string(_node)
+    end
+
+    def visit_template(node)
+      node.items.each { |item| visit(item) }
+    end
+
+    def visit_text(_node)
+    end
+
+    def visit_unless_else(node)
+      visit(node.expression)
+      visit(node.unless_template)
+      visit(node.else_template)
+    end
+
+    def visit_variable(_node)
+    end
+
+    def visit_with_else(node)
+      visit(node.path)
+      visit(node.with_template)
+      visit(node.else_template)
+    end
+  end
+end

--- a/spec/integration/visitor_spec.rb
+++ b/spec/integration/visitor_spec.rb
@@ -1,0 +1,146 @@
+describe "visitor" do
+  let(:source) do
+    <<-HBS
+      {{#print_args_and_options 'first' 'second' key='value'}}
+      {{/print_args_and_options}}
+
+      {{#render_inverse}}
+        fn
+      {{else}}
+        inverse
+        {{@variable}}
+      {{/render_inverse}}
+
+      {{#each foo}}
+        top
+        {{#each bar}}
+          middle
+          {{#each baz}}
+            inner
+          {{else}}
+            inner inverse
+          {{/each}}
+        {{/each}}
+      {{/each}}
+
+      {{#if valid}}
+        if_template
+        {{#if bar}}
+          foo
+        {{else}}
+          qux
+        {{/if}}
+      {{/if}}
+
+      {{#if baz}}
+        qux
+      {{/if}}
+
+      {{> partial}}
+
+      {{user.avatar.url}}
+      {{#with this}}
+        {{user.avatar.url}}
+      {{/with}}
+
+      {{#unless things}}
+        hi
+      {{/unless}}
+    HBS
+  end
+
+  describe ".visit" do
+    it "visits BlockHelperElse nodes" do
+      visitor = counting_visitor_for(Curlybars::Node::BlockHelperElse)
+      output = Curlybars.visit(visitor, source)
+      expect(output).to eq(4)
+    end
+
+    it "visits EachElse nodes" do
+      visitor = counting_visitor_for(Curlybars::Node::EachElse)
+      output = Curlybars.visit(visitor, source)
+      expect(output).to eq(3)
+    end
+
+    it "visits IfElse nodes" do
+      visitor = counting_visitor_for(Curlybars::Node::IfElse)
+      output = Curlybars.visit(visitor, source)
+      expect(output).to eq(3)
+    end
+
+    it "visits Item nodes" do
+      visitor = counting_visitor_for(Curlybars::Node::Item)
+      output = Curlybars.visit(visitor, source)
+      expect(output).to eq(42)
+    end
+
+    it "visits Literal nodes" do
+      visitor = counting_visitor_for(Curlybars::Node::Literal)
+      output = Curlybars.visit(visitor, source)
+      expect(output).to eq(3)
+    end
+
+    it "visits Option nodes" do
+      visitor = counting_visitor_for(Curlybars::Node::Option)
+      output = Curlybars.visit(visitor, source)
+      expect(output).to eq(1)
+    end
+
+    it "visits Partial nodes" do
+      visitor = counting_visitor_for(Curlybars::Node::Partial)
+      output = Curlybars.visit(visitor, source)
+      expect(output).to eq(1)
+    end
+
+    it "visits Path nodes" do
+      visitor = counting_visitor_for(Curlybars::Node::Path)
+      output = Curlybars.visit(visitor, source)
+      expect(output).to eq(13)
+    end
+
+    it "visits Root nodes" do
+      visitor = counting_visitor_for(Curlybars::Node::Root)
+      output = Curlybars.visit(visitor, source)
+      expect(output).to eq(1)
+    end
+
+    it "visits Template nodes" do
+      visitor = counting_visitor_for(Curlybars::Node::Template)
+      output = Curlybars.visit(visitor, source)
+      expect(output).to eq(14)
+    end
+
+    it "visits Text nodes" do
+      visitor = counting_visitor_for(Curlybars::Node::Text)
+      output = Curlybars.visit(visitor, source)
+      expect(output).to eq(28)
+    end
+
+    it "visits UnlessElse nodes" do
+      visitor = counting_visitor_for(Curlybars::Node::UnlessElse)
+      output = Curlybars.visit(visitor, source)
+      expect(output).to eq(1)
+    end
+
+    it "visits Variable nodes" do
+      visitor = counting_visitor_for(Curlybars::Node::Variable)
+      output = Curlybars.visit(visitor, source)
+      expect(output).to eq(1)
+    end
+
+    it "visits WithElse nodes" do
+      visitor = counting_visitor_for(Curlybars::Node::WithElse)
+      output = Curlybars.visit(visitor, source)
+      expect(output).to eq(1)
+    end
+  end
+
+  def counting_visitor_for(klass)
+    Class.new(Curlybars::Visitor) do
+      define_method "visit_#{klass.name.demodulize.underscore}" do |node|
+        self.context += 1
+        super(node)
+      end
+    end.new(0)
+  end
+end


### PR DESCRIPTION
👋 @zendesk/solaris @zendesk/guide-growth I'm not sure who owns this these days.

We'd like to be able to do some static analysis of certain Curlybars templates. Instead of adding an ad-hoc mechanism for traversing the AST in our application code, it seems to make sense to add an API for doing so to the library itself.

This is my first take, so I'm not married to the exact API. My goal is to be minimally invasive and fairly flexible. 

The `Curlybars.visit` method accepts ~a single callable that will be executed each time a node is *about* to be visited~ a visitor that can specify behavior for nodes it's interested in. The spec demonstrates a simple analysis use-case (counting types of nodes in the parse tree).
