### PR TITLE
Handle out of scope validation

### DIFF
--- a/lib/curlybars/node/item.rb
+++ b/lib/curlybars/node/item.rb
@@ -15,9 +15,7 @@ module Curlybars
       end
 
       def validate(branches)
-        catch(:skip_item_validation) do
-          item.validate(branches)
-        end
+        item.validate(branches)
       end
 
       def cache_key

--- a/lib/curlybars/node/item.rb
+++ b/lib/curlybars/node/item.rb
@@ -16,6 +16,8 @@ module Curlybars
 
       def validate(branches)
         item.validate(branches)
+      rescue Curlybars::Error::Validate => path_error
+        path_error
       end
 
       def cache_key

--- a/lib/curlybars/node/path.rb
+++ b/lib/curlybars/node/path.rb
@@ -62,6 +62,9 @@ module Curlybars
           base_tree_position = branches.length - backward_steps_on_branches
 
           base_tree_index = base_tree_position - 1
+
+          raise Curlybars::Error::Validate.new('unallowed_path', "'#{path}' goes out of scope", position) unless base_tree_index >= 0
+
           base_tree = branches[base_tree_index]
 
           dotted_path_side = path_split_by_slashes.last

--- a/lib/curlybars/node/path.rb
+++ b/lib/curlybars/node/path.rb
@@ -61,8 +61,6 @@ module Curlybars
           backward_steps_on_branches = path_split_by_slashes.count - 1
           base_tree_position = branches.length - backward_steps_on_branches
 
-          throw :skip_item_validation unless base_tree_position > 0
-
           base_tree_index = base_tree_position - 1
           base_tree = branches[base_tree_index]
 

--- a/lib/curlybars/node/path.rb
+++ b/lib/curlybars/node/path.rb
@@ -62,7 +62,7 @@ module Curlybars
           base_tree_position = branches.length - backward_steps_on_branches
           base_tree_index = base_tree_position - 1
 
-          raise Curlybars::Error::Validate.new('unallowed_path', "'#{path}' goes out of scope", position) unless base_tree_index >= 0
+          raise Curlybars::Error::Validate.new('unallowed_path', "'#{path}' goes out of scope", position) if base_tree_index < 0
 
           base_tree = branches[base_tree_index]
 

--- a/lib/curlybars/node/path.rb
+++ b/lib/curlybars/node/path.rb
@@ -60,7 +60,6 @@ module Curlybars
           path_split_by_slashes = path.split('/')
           backward_steps_on_branches = path_split_by_slashes.count - 1
           base_tree_position = branches.length - backward_steps_on_branches
-
           base_tree_index = base_tree_position - 1
 
           raise Curlybars::Error::Validate.new('unallowed_path', "'#{path}' goes out of scope", position) unless base_tree_index >= 0

--- a/spec/integration/node/if_else_spec.rb
+++ b/spec/integration/node/if_else_spec.rb
@@ -144,13 +144,29 @@ describe "{{#if}}...{{else}}...{{/if}}" do
       source = <<-HBS
         {{#if ../condition}}
         {{else}}
-          {{unallowed_method}}
+          {{unallowed_ELSE_method}}
         {{/if}}
       HBS
 
       errors = Curlybars.validate(dependency_tree, source)
 
-      expect(errors).not_to be_empty
+      expect(errors.count).to eq(2)
+    end
+
+    it "gives all possible errors found in validation" do
+      dependency_tree = { condition: nil }
+
+      source = <<-HBS
+        {{#if ../condition}}
+          {{unallowed_IF_method}}
+        {{else}}
+          {{unallowed_ELSE_method}}
+        {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors.count).to eq(3)
     end
   end
 end

--- a/spec/integration/node/if_else_spec.rb
+++ b/spec/integration/node/if_else_spec.rb
@@ -137,5 +137,20 @@ describe "{{#if}}...{{else}}...{{/if}}" do
 
       expect(errors).not_to be_empty
     end
+
+    it "validates errors the nested else_template when out of context" do
+      dependency_tree = { condition: nil }
+
+      source = <<-HBS
+        {{#if ../condition}}
+        {{else}}
+          {{unallowed_method}}
+        {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).not_to be_empty
+    end
   end
 end

--- a/spec/integration/node/path_spec.rb
+++ b/spec/integration/node/path_spec.rb
@@ -257,6 +257,18 @@ describe "{{path}}" do
         end
       end
 
+      it "with errors when going outside of scope" do
+        dependency_tree = { ok: { unallowed: { ok: nil } } }
+
+        source = <<~HBS
+          {{../ok.unallowed.ok}}
+        HBS
+
+        errors = Curlybars.validate(dependency_tree, source)
+
+        expect(errors.first.message).to eq("'../ok.unallowed.ok' goes out of scope")
+      end
+
       describe "raises exact location of unallowed steps" do
         let(:dependency_tree) { { ok: { allowed: { ok: nil } } } }
 

--- a/spec/integration/node/path_spec.rb
+++ b/spec/integration/node/path_spec.rb
@@ -258,15 +258,15 @@ describe "{{path}}" do
       end
 
       it "with errors when going outside of scope" do
-        dependency_tree = { ok: { unallowed: { ok: nil } } }
+        dependency_tree = { ok: { ok: { ok: nil } } }
 
         source = <<~HBS
-          {{../ok.unallowed.ok}}
+          {{../ok.ok.ok}}
         HBS
 
         errors = Curlybars.validate(dependency_tree, source)
 
-        expect(errors.first.message).to eq("'../ok.unallowed.ok' goes out of scope")
+        expect(errors.first.message).to eq("'../ok.ok.ok' goes out of scope")
       end
 
       describe "raises exact location of unallowed steps" do

--- a/spec/integration/node/path_spec.rb
+++ b/spec/integration/node/path_spec.rb
@@ -139,7 +139,7 @@ describe "{{path}}" do
       expect(errors).to be_empty
     end
 
-    it "without errors when it goes out of context" do
+    it "gives errors errors when it goes out of context" do
       dependency_tree = {}
 
       source = <<-HBS
@@ -148,7 +148,7 @@ describe "{{path}}" do
 
       errors = Curlybars.validate(dependency_tree, source)
 
-      expect(errors).to be_empty
+      expect(errors).not_to be_empty
     end
 
     it "without errors using `this`" do


### PR DESCRIPTION
Removing :skip_validation in order to allow users to know if they're out of scope. 

The currently implementation has an unfortunate side-effect, of skipping the complete validation of an if_else block, in case the skip_item_validation gets raised. Which means that nothing inside the if-else gets validated, but breaks during compilation. 

It seems like the :skip_item_validation was added purposefully, but I couldn't find any documentation regarding `why`. 

Having item::validate rescue the Validation error, to make sure that all errors are correctly returned; 
In the previous version, if an error happened in the if_else.rb validate flow, it would only throw that specific error and not all of the possible errors encountered. 