### PR TITLE
Add support for whitelisting methods based on context

### DIFF
--- a/lib/curlybars/method_whitelist.rb
+++ b/lib/curlybars/method_whitelist.rb
@@ -1,27 +1,53 @@
 module Curlybars
   module MethodWhitelist
-    def allow_methods(*methods, **methods_with_type)
-      methods_with_type.each do |(method_name, type)|
-        if type.is_a?(Array)
-          if type.size != 1 || !type.first.respond_to?(:dependency_tree)
-            raise "Invalid allowed method syntax for `#{method_name}`. Collections must be of one presenter class"
+    def allow_methods(*methods, **methods_with_type, &contextual_methods)
+      methods_with_type_validator = lambda do |methods_to_validate|
+        methods_to_validate.each do |(method_name, type)|
+          if type.is_a?(Array)
+            if type.size != 1 || !type.first.respond_to?(:dependency_tree)
+              raise "Invalid allowed method syntax for `#{method_name}`. Collections must be of one presenter class"
+            end
           end
         end
       end
 
+      methods_with_type_validator.call(methods_with_type)
+
       define_method(:allowed_methods) do
         methods_list = methods + methods_with_type.keys
+
+        # Adds methods to the list of allowed methods
+        method_adder = lambda do |*more_methods, **more_methods_with_type|
+          methods_with_type_validator.call(more_methods_with_type)
+          methods_list += more_methods
+          methods_list += more_methods_with_type.keys
+        end
+
+        contextual_methods&.call(self, method_adder)
+
         defined?(super) ? super() + methods_list : methods_list
       end
 
-      define_singleton_method(:methods_schema) do |*args|
-        schema = methods.each_with_object({}) do |method, memo|
+      define_singleton_method(:methods_schema) do |context = nil|
+        all_methods = methods
+        all_methods_with_type = methods_with_type
+
+        # Adds methods to the schema
+        schema_adder = lambda do |*more_methods, **more_methods_with_type|
+          methods_with_type_validator.call(more_methods_with_type)
+          all_methods += more_methods
+          all_methods_with_type = all_methods_with_type.merge(more_methods_with_type)
+        end
+
+        contextual_methods&.call(context, schema_adder)
+
+        schema = all_methods.each_with_object({}) do |method, memo|
           memo[method] = nil
         end
 
-        methods_with_type_resolved = methods_with_type.each_with_object({}) do |(method_name, type), memo|
+        methods_with_type_resolved = all_methods_with_type.each_with_object({}) do |(method_name, type), memo|
           memo[method_name] = if type.respond_to?(:call)
-            type.call(*args)
+            type.call(context)
           else
             type
           end
@@ -30,26 +56,26 @@ module Curlybars
         schema.merge!(methods_with_type_resolved)
 
         # Inheritance
-        schema.merge!(super(*args)) if defined?(super)
+        schema.merge!(super(context)) if defined?(super)
 
         # Included modules
         included_modules.each do |mod|
           next unless mod.respond_to?(:methods_schema)
-          schema.merge!(mod.methods_schema(*args))
+          schema.merge!(mod.methods_schema(context))
         end
 
         schema
       end
 
-      define_singleton_method(:dependency_tree) do |*args|
-        methods_schema(*args).each_with_object({}) do |method_with_type, memo|
+      define_singleton_method(:dependency_tree) do |context = nil|
+        methods_schema(context).each_with_object({}) do |method_with_type, memo|
           method_name = method_with_type.first
           type = method_with_type.last
 
           memo[method_name] = if type.respond_to?(:dependency_tree)
-            type.dependency_tree(*args)
+            type.dependency_tree(context)
           elsif type.is_a?(Array)
-            [type.first.dependency_tree(*args)]
+            [type.first.dependency_tree(context)]
           else
             type
           end

--- a/spec/curlybars/method_whitelist_spec.rb
+++ b/spec/curlybars/method_whitelist_spec.rb
@@ -7,6 +7,10 @@ describe Curlybars::MethodWhitelist do
       def foo?
         true
       end
+
+      def qux?
+        false
+      end
     end
   end
 
@@ -14,6 +18,10 @@ describe Curlybars::MethodWhitelist do
     Class.new do
       def foo?
         true
+      end
+
+      def qux?
+        false
       end
     end
   end
@@ -43,6 +51,10 @@ describe Curlybars::MethodWhitelist do
         allow_methods do |context, allow_method|
           if context.foo?
             allow_method.call(:bar)
+          end
+
+          if context.qux?
+            allow_method.call(:quux)
           end
         end
       end

--- a/spec/curlybars/method_whitelist_spec.rb
+++ b/spec/curlybars/method_whitelist_spec.rb
@@ -38,7 +38,7 @@ describe Curlybars::MethodWhitelist do
       expect(dummy_class.new.allowed_methods).to eq([:cook, :link, :article])
     end
 
-    it "supports contextual methods" do
+    it "supports adding more methods for validation" do
       dummy_class.class_eval do
         allow_methods do |context, allow_method|
           if context.foo?
@@ -47,7 +47,7 @@ describe Curlybars::MethodWhitelist do
         end
       end
 
-      aggregate_failures do
+      aggregate_failures "test both allowed_methods and allows_method?" do
         expect(dummy_class.new.allowed_methods).to eq([:bar])
         expect(dummy_class.new.allows_method?(:bar)).to eq(true)
       end

--- a/spec/curlybars/method_whitelist_spec.rb
+++ b/spec/curlybars/method_whitelist_spec.rb
@@ -1,5 +1,22 @@
 describe Curlybars::MethodWhitelist do
-  let(:dummy_class) { Class.new { extend Curlybars::MethodWhitelist } }
+  let(:dummy_class) do
+    Class.new do
+      extend Curlybars::MethodWhitelist
+
+      # A method available in the context
+      def foo?
+        true
+      end
+    end
+  end
+
+  let(:validation_context_class) do
+    Class.new do
+      def foo?
+        true
+      end
+    end
+  end
 
   describe "#allowed_methods" do
     it "returns an empty array as default" do
@@ -19,6 +36,21 @@ describe Curlybars::MethodWhitelist do
 
     it "sets the allowed methods" do
       expect(dummy_class.new.allowed_methods).to eq([:cook, :link, :article])
+    end
+
+    it "supports contextual methods" do
+      dummy_class.class_eval do
+        allow_methods do |context, allow_method|
+          if context.foo?
+            allow_method.call(:bar)
+          end
+        end
+      end
+
+      aggregate_failures do
+        expect(dummy_class.new.allowed_methods).to eq([:bar])
+        expect(dummy_class.new.allows_method?(:bar)).to eq(true)
+      end
     end
 
     it "raises when collection is not of presenters" do
@@ -79,6 +111,68 @@ describe Curlybars::MethodWhitelist do
           wave: nil
         )
     end
+
+    context "with context dependent methods" do
+      let(:base_presenter) do
+        stub_const("LinkPresenter", Class.new)
+
+        Class.new do
+          extend Curlybars::MethodWhitelist
+          allow_methods :cook, link: LinkPresenter do |context, allow_method|
+            if context.foo?
+              allow_method.call(:bar)
+            end
+          end
+
+          def foo?
+            true
+          end
+        end
+      end
+
+      let(:helpers) do
+        Module.new do
+          extend Curlybars::MethodWhitelist
+          allow_methods :form do |context, allow_method|
+            if context.foo?
+              allow_method.call(foo_bar: :helper)
+            end
+          end
+
+          def foo?
+            true
+          end
+        end
+      end
+
+      let(:post_presenter) do
+        Class.new(base_presenter) do
+          extend Curlybars::MethodWhitelist
+          include Helpers
+          allow_methods :wave
+        end
+      end
+
+      before do
+        stub_const("Helpers", helpers)
+      end
+
+      it "allows context methods from inheritance and composition" do
+        expect(post_presenter.new.allowed_methods).to eq([:cook, :link, :bar, :form, :foo_bar, :wave])
+      end
+
+      it "returns a dependency_tree with inheritance and composition with context" do
+        expect(post_presenter.dependency_tree(validation_context_class.new)).
+          to eq(
+            cook: nil,
+            link: LinkPresenter,
+            form: nil,
+            wave: nil,
+            bar: nil,
+            foo_bar: :helper
+          )
+      end
+    end
   end
 
   describe ".methods_schema" do
@@ -110,16 +204,22 @@ describe Curlybars::MethodWhitelist do
       expect(dummy_class.methods_schema).to eq(links: [LinkPresenter])
     end
 
-    it "supports procs in schema" do
-      dummy_class.class_eval { allow_methods settings: -> { { color_1: nil } } }
+    it "supports procs with context in schema" do
+      dummy_class.class_eval { allow_methods settings: ->(context) { context.foo? ? Hash[:background_color, nil] : nil } }
 
-      expect(dummy_class.methods_schema).to eq(settings: { color_1: nil })
+      expect(dummy_class.methods_schema(validation_context_class.new)).to eq(settings: { background_color: nil })
     end
 
-    it "supports procs with arguments in schema" do
-      dummy_class.class_eval { allow_methods settings: ->(name) { Hash[name, nil] } }
+    it "supports context methods" do
+      dummy_class.class_eval do
+        allow_methods do |context, allow_method|
+          if context.foo?
+            allow_method.call(:bar)
+          end
+        end
+      end
 
-      expect(dummy_class.methods_schema(:background_color)).to eq(settings: { background_color: nil })
+      expect(dummy_class.methods_schema(validation_context_class.new)).to eq(bar: nil)
     end
   end
 


### PR DESCRIPTION
Sometimes it is useful to exclude/include some methods for the same presenter in situations where the context is stable between validation and execution.

This PR adds a way to receive a `context` object both during validation, that can be used like this:

``` ruby
allow_methods do |context, method_allower|
    if context.foo?
      method_allower.call(:my_method)
    end
  end
```