### PR TITLE
Memoize result of allowed_methods

### DIFF
--- a/lib/curlybars/method_whitelist.rb
+++ b/lib/curlybars/method_whitelist.rb
@@ -14,19 +14,21 @@ module Curlybars
       methods_with_type_validator.call(methods_with_type)
 
       define_method(:allowed_methods) do
-        methods_list = methods_without_type + methods_with_type.keys
+        @method_whitelist_allowed_methods ||= begin
+          methods_list = methods_without_type + methods_with_type.keys
 
-        # Adds methods to the list of allowed methods
-        method_adder = lambda do |*more_methods, **more_methods_with_type|
-          methods_with_type_validator.call(more_methods_with_type)
+          # Adds methods to the list of allowed methods
+          method_adder = lambda do |*more_methods, **more_methods_with_type|
+            methods_with_type_validator.call(more_methods_with_type)
 
-          methods_list += more_methods
-          methods_list += more_methods_with_type.keys
+            methods_list += more_methods
+            methods_list += more_methods_with_type.keys
+          end
+
+          contextual_block&.call(self, method_adder)
+
+          defined?(super) ? super() + methods_list : methods_list
         end
-
-        contextual_block&.call(self, method_adder)
-
-        defined?(super) ? super() + methods_list : methods_list
       end
 
       define_singleton_method(:methods_schema) do |context = nil|

--- a/spec/curlybars/method_whitelist_spec.rb
+++ b/spec/curlybars/method_whitelist_spec.rb
@@ -16,7 +16,7 @@ describe Curlybars::MethodWhitelist do
 
   let(:validation_context_class) do
     Class.new do
-      attr_accessor :invocation_count # To test memoization
+      attr_accessor :invocation_count
 
       def foo?
         true
@@ -132,14 +132,13 @@ describe Curlybars::MethodWhitelist do
 
         Class.new do
           extend Curlybars::MethodWhitelist
-          attr_accessor :invocation_count # To test memoization
+          attr_accessor :invocation_count
 
           allow_methods :cook, link: LinkPresenter do |context, allow_method|
             if context.foo?
               allow_method.call(:bar)
             end
 
-            # To test memoization
             context.invocation_count ||= 0
             context.invocation_count += 1
           end

--- a/spec/curlybars/method_whitelist_spec.rb
+++ b/spec/curlybars/method_whitelist_spec.rb
@@ -16,6 +16,8 @@ describe Curlybars::MethodWhitelist do
 
   let(:validation_context_class) do
     Class.new do
+      attr_accessor :invocation_count # To test memoization
+
       def foo?
         true
       end
@@ -130,10 +132,16 @@ describe Curlybars::MethodWhitelist do
 
         Class.new do
           extend Curlybars::MethodWhitelist
+          attr_accessor :invocation_count # To test memoization
+
           allow_methods :cook, link: LinkPresenter do |context, allow_method|
             if context.foo?
               allow_method.call(:bar)
             end
+
+            # To test memoization
+            context.invocation_count ||= 0
+            context.invocation_count += 1
           end
 
           def foo?
@@ -171,6 +179,14 @@ describe Curlybars::MethodWhitelist do
 
       it "allows context methods from inheritance and composition" do
         expect(post_presenter.new.allowed_methods).to eq([:cook, :link, :bar, :form, :foo_bar, :wave])
+      end
+
+      it "only invokes the context block once" do
+        presenter = post_presenter.new
+
+        10.times { presenter.allowed_methods }
+
+        expect(presenter.invocation_count).to eq(1)
       end
 
       it "returns a dependency_tree with inheritance and composition with context" do


### PR DESCRIPTION
In
https://github.com/zendesk/curlybars/blob/e11effb41b0b1f3d778f8c92c8b0d9fc2352b86a/lib/curlybars/rendering_support.rb#L203-L208

Curlybars checks if a method is allowed before calling each method in the presenter.
However, the list of allowed methods was not cached leading to, in the case the presenter is using context dependent methods, executing the block multiple times.

cc @zendesk/guide-growth 
