### PR TITLE
Implement subexpressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Unreleased
 
+### Curlybars 1.5.0 (October 27, 2020)
+* Add basic language support subexpressions (save for `#each`)
+
 ### Curlybars 1.4.0 (September 29, 2020)
 * Allow arg-less helpers in if/unless conditions
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -328,19 +328,13 @@ There are {{recipient.entries.length}} entries in this invoice.
 
 ## Subexpressions
 
-Curlybars, similarly to [Handlebars](https://handlebarsjs.com/guide/expressions.html#subexpressions), offers support for subexpressions, which allows you to invoke multiple helpers within a single expression, and pass in the results of inner helper invocations as arguments to outer helpers. Subexpressions are delimited by parentheses.
+Curlybars offers limited support for [subexpressions](https://handlebarsjs.com/guide/expressions.html#subexpressions), which allows you to invoke multiple helpers within a single expression, and pass in the results of inner helper invocations as arguments to outer helpers. Subexpressions are delimited by parentheses.
 
-Let's explore some of the use cases subexpressions open up.
-
-### Nested subexpressions and collections
+### Nested subexpressions
 
 ```hbs
-{{#each (first (filter collection on="attribute" op="equals" value="value") 5)}}
-  <div><!-- Presents the item of collection --></div>
-{{/each}}
+{{search placeholder=(lowercasecase (dc "search_text"))}}
 ```
-
-Assume a collection called `collection` and helpers `first` and `filter`. This template renders the first 5 items of `collection` whose `attribute` equals to `value`.
 
 ### Conditionals
 
@@ -351,6 +345,10 @@ Assume a collection called `collection` and helpers `first` and `filter`. This t
   <div>Your collection has {{collection.length}} items</div>
 {{/if}}
 ```
+
+### Each
+
+Subexpressions in `each` statements are currently *not* supported.
 
 ## Analysis
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -333,7 +333,7 @@ Curlybars offers limited support for [subexpressions](https://handlebarsjs.com/g
 ### Nested subexpressions
 
 ```hbs
-{{search placeholder=(lowercasecase (dc "search_text"))}}
+{{search placeholder=(lowercase (dc "search_text"))}}
 ```
 
 ### Conditionals

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -326,6 +326,32 @@ There are {{recipient.entries.length}} entries in this invoice.
 </ul>
 ```
 
+## Subexpressions
+
+Curlybars, similarly to [Handlebars](https://handlebarsjs.com/guide/expressions.html#subexpressions), offers support for subexpressions, which allows you to invoke multiple helpers within a single expression, and pass in the results of inner helper invocations as arguments to outer helpers. Subexpressions are delimited by parentheses.
+
+Let's explore some of the use cases subexpressions open up.
+
+### Nested subexpressions and collections
+
+```hbs
+{{#each (first (filter collection on="attribute" op="equals" value="value") 5)}}
+  <div><!-- Presents the item of collection --></div>
+{{/each}}
+```
+
+Assume a collection called `collection` and helpers `first` and `filter`. This template renders the first 5 items of `collection` whose `attribute` equals to `value`.
+
+### Conditionals
+
+```hbs
+{{#if (eval collection.length "==" 0)}}
+  <div>Empty collection.</div>
+{{else}}
+  <div>Your collection has {{collection.length}} items</div>
+{{/if}}
+```
+
 ## Analysis
 
 Curlybars exposes a `.visit` method for traversing a template's parse tree. This can be used to analyze templates without actually rendering them.

--- a/lib/curlybars/lexer.rb
+++ b/lib/curlybars/lexer.rb
@@ -32,6 +32,9 @@ module Curlybars
     r(/{{/) { push_state :curly; :START }
     r(/}}/, :curly) { pop_state; :END }
 
+    r(/\(/, :curly) { push_state :curly; :LPAREN }
+    r(/\)/, :curly) { pop_state; :RPAREN }
+
     r(/#/, :curly) { :HASH }
     r(/\//, :curly) { :SLASH }
     r(/>/, :curly) { :GT }

--- a/lib/curlybars/node/sub_expression.rb
+++ b/lib/curlybars/node/sub_expression.rb
@@ -39,7 +39,21 @@ module Curlybars
       end
 
       def validate(branches, check_type: :anything)
-        # Nothing to validate here.
+        if helper.leaf?(branches)
+          if arguments.any? || options.any?
+            message = "#{helper.path} doesn't accept any arguments or options"
+            Curlybars::Error::Validate.new('invalid_signature', message, helper.position)
+          end
+        elsif helper.helper?(branches)
+          [
+            helper.validate(branches),
+            arguments.map { |argument| argument.validate_as_value(branches) },
+            options.map { |option| option.validate(branches) }
+          ]
+        else
+          message = "#{helper.path} must be allowed as helper or leaf"
+          Curlybars::Error::Validate.new('invalid_subexpression_helper', message, helper.position)
+        end
       end
 
       def cache_key

--- a/lib/curlybars/node/sub_expression.rb
+++ b/lib/curlybars/node/sub_expression.rb
@@ -1,0 +1,54 @@
+module Curlybars
+  module Node
+    SubExpression = Struct.new(:helper, :arguments, :options, :position) do
+      def compile
+        compiled_arguments = arguments.map do |argument|
+          "arguments.push(rendering.cached_call(#{argument.compile}))"
+        end.join("\n")
+
+        compiled_options = options.map do |option|
+          "options.merge!(#{option.compile})"
+        end.join("\n")
+
+        # NOTE: the following is a heredoc string, representing the ruby code fragment
+        # outputted by this node.
+        <<-RUBY
+          ::Module.new do
+            def self.exec(contexts, rendering)
+              rendering.check_timeout!
+
+              -> {
+                options = ::ActiveSupport::HashWithIndifferentAccess.new
+                #{compiled_options}
+
+                arguments = []
+                #{compiled_arguments}
+
+                helper = #{helper.compile}
+                helper_position = rendering.position(#{helper.position.line_number},
+                  #{helper.position.line_offset})
+
+                options[:this] = contexts.last
+
+                rendering.call(helper, #{helper.path.inspect}, helper_position,
+                  arguments, options)
+              }
+            end
+          end.exec(contexts, rendering)
+        RUBY
+      end
+
+      def validate(branches, check_type: :anything)
+        # Nothing to validate here.
+      end
+
+      def cache_key
+        [
+          helper,
+          arguments,
+          options
+        ].flatten.map(&:cache_key).push(self.class.name).join("/")
+      end
+    end
+  end
+end

--- a/lib/curlybars/node/sub_expression.rb
+++ b/lib/curlybars/node/sub_expression.rb
@@ -43,16 +43,11 @@ module Curlybars
       end
 
       def validate(branches, check_type: :anything)
-        if helper.helper?(branches)
-          [
-            helper.validate(branches),
-            arguments.map { |argument| argument.validate_as_value(branches) },
-            options.map { |option| option.validate(branches) }
-          ]
-        else
-          message = "#{helper.path} must be allowed as a helper"
-          Curlybars::Error::Validate.new('invalid_subexpression_helper', message, helper.position)
-        end
+        [
+          helper.validate(branches, check_type: :helper),
+          arguments.map { |argument| argument.validate_as_value(branches) },
+          options.map { |option| option.validate(branches) }
+        ]
       end
 
       def cache_key

--- a/lib/curlybars/node/sub_expression.rb
+++ b/lib/curlybars/node/sub_expression.rb
@@ -39,19 +39,14 @@ module Curlybars
       end
 
       def validate(branches, check_type: :anything)
-        if helper.leaf?(branches)
-          if arguments.any? || options.any?
-            message = "#{helper.path} doesn't accept any arguments or options"
-            Curlybars::Error::Validate.new('invalid_signature', message, helper.position)
-          end
-        elsif helper.helper?(branches)
+        if helper.helper?(branches)
           [
             helper.validate(branches),
             arguments.map { |argument| argument.validate_as_value(branches) },
             options.map { |option| option.validate(branches) }
           ]
         else
-          message = "#{helper.path} must be allowed as helper or leaf"
+          message = "#{helper.path} must be allowed as a helper"
           Curlybars::Error::Validate.new('invalid_subexpression_helper', message, helper.position)
         end
       end

--- a/lib/curlybars/node/sub_expression.rb
+++ b/lib/curlybars/node/sub_expression.rb
@@ -38,6 +38,10 @@ module Curlybars
         RUBY
       end
 
+      def validate_as_value(branches, check_type: :anything)
+        validate(branches, check_type: check_type)
+      end
+
       def validate(branches, check_type: :anything)
         if helper.helper?(branches)
           [

--- a/lib/curlybars/parser.rb
+++ b/lib/curlybars/parser.rb
@@ -15,6 +15,7 @@ require 'curlybars/node/block_helper_else'
 require 'curlybars/node/option'
 require 'curlybars/node/partial'
 require 'curlybars/node/output'
+require 'curlybars/node/sub_expression'
 
 module Curlybars
   class Parser < RLTK::Parser
@@ -166,6 +167,12 @@ module Curlybars
     production(:path, 'PATH') { |path| Node::Path.new(path, pos(0)) }
 
     production(:subexpression, 'LPAREN .path .expressions? .options? RPAREN') do |helper, arguments, options|
+      Node::SubExpression.new(
+        helper,
+        arguments || [],
+        options || [],
+        pos(0)
+      )
     end
 
     finalize

--- a/lib/curlybars/parser.rb
+++ b/lib/curlybars/parser.rb
@@ -155,6 +155,7 @@ module Curlybars
     production(:expression) do
       clause('value') { |value| value }
       clause('path') { |path| path }
+      clause('subexpression') { |subexpression| subexpression }
     end
 
     production(:value) do
@@ -163,6 +164,9 @@ module Curlybars
     end
 
     production(:path, 'PATH') { |path| Node::Path.new(path, pos(0)) }
+
+    production(:subexpression, 'LPAREN .path .expressions? .options? RPAREN') do |helper, arguments, options|
+    end
 
     finalize
 

--- a/spec/curlybars/lexer_spec.rb
+++ b/spec/curlybars/lexer_spec.rb
@@ -160,6 +160,28 @@ describe Curlybars::Lexer do
     end
   end
 
+  describe "{{path (path context options)}}" do
+    it "is lexed with path, context and options" do
+      expect(lex('{{path (path context key=value)}}')).to produce [:START, :PATH, :LPAREN, :PATH, :PATH, :KEY, :PATH, :RPAREN, :END]
+    end
+
+    it "is lexed without options" do
+      expect(lex('{{path (path context)}}')).to produce [:START, :PATH, :LPAREN, :PATH, :PATH, :RPAREN, :END]
+    end
+
+    it "is lexed without context" do
+      expect(lex('{{path (path key=value)}}')).to produce [:START, :PATH, :LPAREN, :PATH, :KEY, :PATH, :RPAREN, :END]
+    end
+
+    it "is lexed without context and options" do
+      expect(lex('{{path (path)}}')).to produce [:START, :PATH, :LPAREN, :PATH, :RPAREN, :END]
+    end
+
+    it "is lexed with a nested subexpression" do
+      expect(lex('{{path (path (path context key=value) key=value)}}')).to produce [:START, :PATH, :LPAREN, :PATH, :LPAREN, :PATH, :PATH, :KEY, :PATH, :RPAREN, :KEY, :PATH, :RPAREN, :END]
+    end
+  end
+
   describe "{{#if path}}...{{/if}}" do
     it "is lexed" do
       expect(lex('{{#if path}} text {{/if}}')).to produce(

--- a/spec/dummy/app/models/article.rb
+++ b/spec/dummy/app/models/article.rb
@@ -1,17 +1,11 @@
 class Article
-  def title
-    "The Prince"
-  end
+  attr_reader :id, :title, :comment, :body, :author
 
-  def comment
-    "<script>alert('bad')</script>"
-  end
-
-  def body
-    "This is <strong>important</strong>!"
-  end
-
-  def author
-    User.new(3, "Nicolò")
+  def initialize(id: nil, title: nil, comment: nil, body: nil, author: nil)
+    @id = id || 1
+    @title = title || "The Prince"
+    @comment = comment || "<script>alert('bad')</script>"
+    @body = body || "This is <strong>important</strong>!"
+    @author = author || User.new(3, "Nicolò")
   end
 end

--- a/spec/dummy/app/presenters/shared/article_presenter.rb
+++ b/spec/dummy/app/presenters/shared/article_presenter.rb
@@ -1,0 +1,30 @@
+class Shared::ArticlePresenter
+  extend Curlybars::MethodWhitelist
+  attr_reader :article
+
+  allow_methods :title, :comment, :body, :author
+
+  def initialize(article)
+    @article = article
+  end
+
+  def title
+    article.title
+  end
+
+  def comment
+    article.comment
+  end
+
+  def body
+    article.body.html_safe
+  end
+
+  def author
+    Shared::UserPresenter.new(article.author)
+  end
+
+  def cache_key
+    article.id
+  end
+end

--- a/spec/integration/node/sub_expression_spec.rb
+++ b/spec/integration/node/sub_expression_spec.rb
@@ -303,6 +303,18 @@ describe "{{(helper arg1 arg2 ... key=value ...)}}" do
       expect(errors).to be_empty
     end
 
+    it "without errors if argument is another subexpression" do
+      dependency_tree = { helper: :helper }
+
+      source = <<-HBS
+        {{#if (helper (helper option='argument'))}} ... {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).to be_empty
+    end
+
     it "without errors if option is a leaf" do
       dependency_tree = { helper: :helper, argument: nil }
 
@@ -332,6 +344,18 @@ describe "{{(helper arg1 arg2 ... key=value ...)}}" do
 
       source = <<-HBS
         {{#if (helper option=@var)}} ... {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).to be_empty
+    end
+
+    it "without errors if option is another subexpression" do
+      dependency_tree = { helper: :helper }
+
+      source = <<-HBS
+        {{#if (helper option=(helper))}} ... {{/if}}
       HBS
 
       errors = Curlybars.validate(dependency_tree, source)

--- a/spec/integration/node/sub_expression_spec.rb
+++ b/spec/integration/node/sub_expression_spec.rb
@@ -1,0 +1,238 @@
+describe "{{(helper arg1 arg2 ... key=value ...)}}" do
+  let(:global_helpers_providers) { [IntegrationTest::GlobalHelperProvider.new] }
+
+  describe "#compile" do
+    let(:presenter) { IntegrationTest::Presenter.new(double("view_context")) }
+
+    it "can be an argument to helpers" do
+      template = Curlybars.compile(<<-HBS)
+        {{global_helper (global_helper 'argument' option='value') option='value'}}
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        argument - option:value - option:value
+      HTML
+    end
+
+    it "can be an argument to itself" do
+      template = Curlybars.compile(<<-HBS)
+        {{global_helper (global_helper (global_helper 'a' option='b') option='c') option='d'}}
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        a - option:b - option:c - option:d
+      HTML
+    end
+
+    it "can handle data objects as argument" do
+      template = Curlybars.compile(<<-HBS)
+        {{global_helper (extract user attribute='first_name') option='value'}}
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        Libo - option:value
+      HTML
+    end
+
+    it "can handle calls inside with" do
+      template = Curlybars.compile(<<-HBS)
+        {{#with article}}
+          {{global_helper (extract author attribute='first_name') option='value'}}
+        {{/with}}
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        Nicolò - option:value
+      HTML
+    end
+
+    it "can handle collections as arguments" do
+      template = Curlybars.compile(<<-HBS)
+        {{join (filter articles on='title' starts_with="A") attribute='title' separator='-'}}
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        A1-A2
+      HTML
+    end
+
+    it "does not accept subexpressions in the root" do
+      expect do
+        Curlybars.compile(<<-HBS)
+          {{(join articles attribute='title' separator='-'}}
+        HBS
+      end.to raise_error(Curlybars::Error::Parse)
+    end
+
+    it "can be called within if expressions" do
+      template = Curlybars.compile(<<-HBS)
+        {{#if (calc 3 ">" 1)}}
+          True
+        {{/if}}
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        True
+      HTML
+    end
+
+    # Replication of Handlebars' subexpression specs for feature parity
+    # https://github.com/handlebars-lang/handlebars.js/blob/1a08e1d0a7f500f2c1188cbd21750bb9180afcbb/spec/subexpressions.js
+
+    it "arg-less helper" do
+      template = Curlybars.compile(<<-HBS)
+        {{foo (bar)}}!
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        LOLLOL!
+      HTML
+    end
+
+    context "with blog presenter" do
+      let(:presenter) do
+        IntegrationTest::BlogPresenter.new(
+          lambda { |*args, options|
+            val = args.first
+            "val is #{val}"
+          }
+        )
+      end
+
+      it "helper w args" do
+        template = Curlybars.compile(<<-HBS)
+          {{blog (equal a b)}}
+        HBS
+
+        expect(eval(template)).to resemble(<<-HTML)
+          val is true
+        HTML
+      end
+
+      it "supports much nesting" do
+        template = Curlybars.compile(<<-HBS)
+          {{blog (equal (equal true true) true)}}
+        HBS
+
+        expect(eval(template)).to resemble(<<-HTML)
+          val is true
+        HTML
+      end
+
+      it "with hashes" do
+        template = Curlybars.compile(<<-HBS)
+          {{blog (equal (equal true true) true fun='yes')}}
+        HBS
+
+        expect(eval(template)).to resemble(<<-HTML)
+          val is true
+        HTML
+      end
+    end
+
+    context "with a different blog presenter" do
+      let(:presenter) do
+        IntegrationTest::BlogPresenter.new(
+          lambda { |*args, options|
+            "val is #{options[:fun]}"
+          }
+        )
+      end
+
+      it "as hashes" do
+        template = Curlybars.compile(<<-HBS)
+          {{blog fun=(equal (blog fun=1) 'val is 1')}}
+        HBS
+
+        expect(eval(template)).to resemble(<<-HTML)
+          val is true
+        HTML
+      end
+    end
+
+    context "with yet another blog presenter" do
+      let(:presenter) do
+        IntegrationTest::BlogPresenter.new(
+          lambda { |*args, options|
+            first, second, third = args
+            "val is #{first}, #{second} and #{third}"
+          }
+        )
+      end
+
+      it "mixed paths and helpers" do
+        template = Curlybars.compile(<<-HBS)
+          {{blog baz.bat (equal a b) baz.bar}}
+        HBS
+
+        expect(eval(template)).to resemble(<<-HTML)
+          val is foo!, true and bar!
+        HTML
+      end
+    end
+
+    describe "GH-800 : Complex subexpressions" do
+      let(:presenter) do
+        IntegrationTest::LetterPresenter.new(
+          a: 'a', b: 'b', c: { c: 'c' }, d: 'd', e: { e: 'e' }
+        )
+      end
+
+      it "can handle complex subexpressions" do
+        inputs = [
+          "{{dash 'abc' (concat a b)}}",
+          "{{dash d (concat a b)}}",
+          "{{dash c.c (concat a b)}}",
+          "{{dash (concat a b) c.c}}",
+          "{{dash (concat a e.e) c.c}}"
+        ]
+
+        expected_results = [
+          "abc-ab",
+          "d-ab",
+          "c-ab",
+          "ab-c",
+          "ae-c"
+        ]
+
+        aggregate_failures do
+          inputs.each_with_index do |input, i|
+            expect(eval(Curlybars.compile(input))).to resemble(expected_results[i])
+          end
+        end
+      end
+    end
+
+    it "multiple subexpressions in a hash" do
+      template = Curlybars.compile(<<-HBS)
+        {{input aria-label=(t "Name") placeholder=(t "Example User")}}
+      HBS
+
+      expected_output = '<input aria-label="Name" placeholder="Example User" />'
+                        .gsub("<", "&lt;")
+                        .gsub(">", "&gt;")
+                        .gsub('"', "&quot;")
+
+      expect(eval(template)).to resemble(expected_output)
+    end
+
+    context "with item show presenter" do
+      let(:presenter) do
+        IntegrationTest::ItemShowPresenter.new(field: "Name", placeholder: "Example User")
+      end
+
+      it "multiple subexpressions in a hash with context" do
+        template = Curlybars.compile(<<-HBS)
+          {{input aria-label=(t item.field) placeholder=(t item.placeholder)}}
+        HBS
+
+        expected_output = '<input aria-label="Name" placeholder="Example User" />'
+                          .gsub("<", "&lt;")
+                          .gsub(">", "&gt;")
+                          .gsub('"', "&quot;")
+
+        expect(eval(template)).to resemble(expected_output)
+      end
+    end
+  end
+end

--- a/spec/integration/node/sub_expression_spec.rb
+++ b/spec/integration/node/sub_expression_spec.rb
@@ -422,5 +422,17 @@ describe "{{(helper arg1 arg2 ... key=value ...)}}" do
 
       expect(errors).not_to be_empty
     end
+
+    it "without errors when invoking a helper with the result of a subexpression" do
+      dependency_tree = { join: :helper, filter: :helper, articles: nil }
+
+      source = <<-HBS
+        {{join (filter articles on='title' starts_with="A") attribute='title' separator='-'}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).to be_empty
+    end
   end
 end

--- a/spec/integration/node/sub_expression_spec.rb
+++ b/spec/integration/node/sub_expression_spec.rb
@@ -46,16 +46,6 @@ describe "{{(helper arg1 arg2 ... key=value ...)}}" do
       HTML
     end
 
-    it "can handle collections as arguments" do
-      template = Curlybars.compile(<<-HBS)
-        {{join (filter articles on='title' starts_with="A") attribute='title' separator='-'}}
-      HBS
-
-      expect(eval(template)).to resemble(<<-HTML)
-        A1-A2
-      HTML
-    end
-
     it "does not accept subexpressions in the root" do
       expect do
         Curlybars.compile(<<-HBS)
@@ -424,10 +414,10 @@ describe "{{(helper arg1 arg2 ... key=value ...)}}" do
     end
 
     it "without errors when invoking a helper with the result of a subexpression" do
-      dependency_tree = { join: :helper, filter: :helper, articles: nil }
+      dependency_tree = { join: :helper, uppercase: :helper, article: nil }
 
       source = <<-HBS
-        {{join (filter articles on='title' starts_with="A") attribute='title' separator='-'}}
+        {{join (uppercase article) attribute='title' separator='-'}}
       HBS
 
       errors = Curlybars.validate(dependency_tree, source)

--- a/spec/integration/node/sub_expression_spec.rb
+++ b/spec/integration/node/sub_expression_spec.rb
@@ -166,7 +166,7 @@ describe "{{(helper arg1 arg2 ... key=value ...)}}" do
         HBS
 
         expect(eval(template)).to resemble(<<-HTML)
-          val is foo!, true and bar!
+          val is bat!, true and bar!
         HTML
       end
     end

--- a/spec/integration/node/sub_expression_spec.rb
+++ b/spec/integration/node/sub_expression_spec.rb
@@ -235,4 +235,168 @@ describe "{{(helper arg1 arg2 ... key=value ...)}}" do
       end
     end
   end
+
+  describe "#validate" do
+    let(:presenter_class) { double(:presenter_class) }
+
+    before do
+      allow(Curlybars.configuration).to receive(:global_helpers_provider_classes).and_return([IntegrationTest::GlobalHelperProvider])
+    end
+
+    it "without errors when global helper" do
+      dependency_tree = {}
+
+      source = <<-HBS
+        {{#if (global_helper)}} ... {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).to be_empty
+    end
+
+    it "without errors when invoking a leaf" do
+      dependency_tree = { name: nil }
+
+      source = <<-HBS
+        {{#if (name)}} ... {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).to be_empty
+    end
+
+    it "without errors if argument is a leaf" do
+      dependency_tree = { helper: :helper, argument: nil }
+
+      source = <<-HBS
+        {{#if (helper argument)}} ... {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).to be_empty
+    end
+
+    it "without errors if argument is a literal" do
+      dependency_tree = { helper: :helper }
+
+      source = <<-HBS
+        {{#if (helper 'argument')}} ... {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).to be_empty
+    end
+
+    it "without errors if argument is a variable" do
+      dependency_tree = { helper: :helper }
+
+      source = <<-HBS
+        {{#if (helper @var)}} ... {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).to be_empty
+    end
+
+    it "without errors if option is a leaf" do
+      dependency_tree = { helper: :helper, argument: nil }
+
+      source = <<-HBS
+        {{#if (helper option=argument)}} ... {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).to be_empty
+    end
+
+    it "without errors if option is a literal" do
+      dependency_tree = { helper: :helper }
+
+      source = <<-HBS
+        {{#if (helper option='argument')}} ... {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).to be_empty
+    end
+
+    it "without errors if option is a variable" do
+      dependency_tree = { helper: :helper }
+
+      source = <<-HBS
+        {{#if (helper option=@var)}} ... {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).to be_empty
+    end
+
+    it "with errors when helper does not exist" do
+      dependency_tree = {}
+
+      source = <<-HBS
+        {{#if (helper)}} ... {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).not_to be_empty
+    end
+
+    it "with errors when invoking a leaf with arguments" do
+      dependency_tree = { name: nil }
+
+      source = <<-HBS
+        {{#if (name 'argument')}} ... {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).not_to be_empty
+    end
+
+    it "with errors when invoking a leaf with options" do
+      dependency_tree = { name: nil }
+
+      source = <<-HBS
+        {{#if (name option='value')}} ... {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).not_to be_empty
+    end
+
+    it "with errors if argument is not a value" do
+      dependency_tree = { helper: :helper, not_a_value: {} }
+
+      source = <<-HBS
+        {{#if (helper not_a_value)}} ... {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).not_to be_empty
+    end
+
+    it "with errors if option is not a value" do
+      dependency_tree = { helper: :helper, not_a_value: {} }
+
+      source = <<-HBS
+        {{#if (helper option=not_a_value)}} ... {{/if}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).not_to be_empty
+    end
+  end
 end

--- a/spec/integration/node/sub_expression_spec.rb
+++ b/spec/integration/node/sub_expression_spec.rb
@@ -255,7 +255,7 @@ describe "{{(helper arg1 arg2 ... key=value ...)}}" do
       expect(errors).to be_empty
     end
 
-    it "without errors when invoking a leaf" do
+    it "with errors when invoking a leaf" do
       dependency_tree = { name: nil }
 
       source = <<-HBS
@@ -264,7 +264,7 @@ describe "{{(helper arg1 arg2 ... key=value ...)}}" do
 
       errors = Curlybars.validate(dependency_tree, source)
 
-      expect(errors).to be_empty
+      expect(errors).not_to be_empty
     end
 
     it "without errors if argument is a leaf" do

--- a/spec/integration/node/sub_expression_spec.rb
+++ b/spec/integration/node/sub_expression_spec.rb
@@ -400,7 +400,7 @@ describe "{{(helper arg1 arg2 ... key=value ...)}}" do
     end
 
     it "with errors if argument is not a value" do
-      dependency_tree = { helper: :helper, not_a_value: {} }
+      dependency_tree = { helper: :helper }
 
       source = <<-HBS
         {{#if (helper not_a_value)}} ... {{/if}}
@@ -412,7 +412,7 @@ describe "{{(helper arg1 arg2 ... key=value ...)}}" do
     end
 
     it "with errors if option is not a value" do
-      dependency_tree = { helper: :helper, not_a_value: {} }
+      dependency_tree = { helper: :helper }
 
       source = <<-HBS
         {{#if (helper option=not_a_value)}} ... {{/if}}

--- a/spec/integration/presenters.rb
+++ b/spec/integration/presenters.rb
@@ -1,0 +1,5 @@
+require 'integration/presenters/baz_presenter'
+require 'integration/presenters/blog_presenter'
+require 'integration/presenters/item_presenter'
+require 'integration/presenters/item_show_presenter'
+require 'integration/presenters/letter_presenter'

--- a/spec/integration/presenters/baz_presenter.rb
+++ b/spec/integration/presenters/baz_presenter.rb
@@ -4,7 +4,7 @@ class BazPresenter
   allow_methods :bat, :bar
 
   def bat
-    "foo!"
+    "bat!"
   end
 
   def bar

--- a/spec/integration/presenters/baz_presenter.rb
+++ b/spec/integration/presenters/baz_presenter.rb
@@ -1,0 +1,13 @@
+class BazPresenter
+  extend Curlybars::MethodWhitelist
+
+  allow_methods :bat, :bar
+
+  def bat
+    "foo!"
+  end
+
+  def bar
+    "bar!"
+  end
+end

--- a/spec/integration/presenters/blog_presenter.rb
+++ b/spec/integration/presenters/blog_presenter.rb
@@ -1,0 +1,29 @@
+require 'integration/presenters/baz_presenter'
+
+module IntegrationTest
+  class BlogPresenter < Curlybars::Presenter
+    attr_reader :blog_builder
+
+    allow_methods :a, :b, :baz, :blog
+
+    def initialize(blog_builder)
+      @blog_builder = blog_builder
+    end
+
+    def a
+      "1"
+    end
+
+    def b
+      "1"
+    end
+
+    def baz
+      BazPresenter.new
+    end
+
+    def blog(arg1, arg2, arg3, options)
+      blog_builder.call(arg1, arg2, arg3, options)
+    end
+  end
+end

--- a/spec/integration/presenters/item_presenter.rb
+++ b/spec/integration/presenters/item_presenter.rb
@@ -1,0 +1,12 @@
+module IntegrationTest
+  class ItemPresenter < Curlybars::Presenter
+    attr_reader :field, :placeholder
+
+    allow_methods :field, :placeholder
+
+    def initialize(field:, placeholder:)
+      @field = field
+      @placeholder = placeholder
+    end
+  end
+end

--- a/spec/integration/presenters/item_show_presenter.rb
+++ b/spec/integration/presenters/item_show_presenter.rb
@@ -1,0 +1,13 @@
+require 'integration/presenters/item_presenter'
+
+module IntegrationTest
+  class ItemShowPresenter < Curlybars::Presenter
+    attr_reader :item
+
+    allow_methods :item
+
+    def initialize(item)
+      @item = ItemPresenter.new(item)
+    end
+  end
+end

--- a/spec/integration/presenters/letter_presenter.rb
+++ b/spec/integration/presenters/letter_presenter.rb
@@ -1,0 +1,23 @@
+module IntegrationTest
+  class LetterPresenter < Curlybars::Presenter
+    attr_reader :alphabet
+
+    allow_methods :a, :b, :c, :d, :e
+
+    def initialize(alphabet)
+      @alphabet = alphabet
+    end
+
+    %i[a b c d e].each do |m|
+      define_method(m) do
+        present(m)
+      end
+    end
+
+    private
+
+    def present(letter)
+      alphabet[letter].is_a?(Hash) ? LetterPresenter.new(alphabet[letter]) : alphabet[letter]
+    end
+  end
+end

--- a/spec/integration/spec_helper.rb
+++ b/spec/integration/spec_helper.rb
@@ -167,7 +167,7 @@ module IntegrationTest
   class GlobalHelperProvider
     extend Curlybars::MethodWhitelist
 
-    allow_methods :global_helper, :extract, :filter, :join,
+    allow_methods :global_helper, :extract, :join,
       :foo, :bar, :equal, :concat, :dash, :input, :t, :calc
 
     def initialize(context = nil)
@@ -213,12 +213,6 @@ module IntegrationTest
 
     def t(argument, _)
       argument.html_safe
-    end
-
-    def filter(collection, options)
-      collection.select do |item|
-        item.public_send(options[:on]).starts_with?(options[:starts_with])
-      end
     end
 
     def join(collection, options)


### PR DESCRIPTION
Following Handlebars Subexpressions feature https://handlebarsjs.com/guide/expressions.html#subexpressions. I tried to replicate most of the [specs](https://github.com/handlebars-lang/handlebars.js/blob/1a08e1d0a7f500f2c1188cbd21750bb9180afcbb/spec/subexpressions.js) covering Handlebars' subexpressions feature. I couldn't figure out how to do it for the last [2 tests](https://github.com/handlebars-lang/handlebars.js/blob/1a08e1d0a7f500f2c1188cbd21750bb9180afcbb/spec/subexpressions.js#L191-L218).

Other than those specs, I also covered some use cases with `with`, `if-else` and around manipulating `collections`. For example the `filter` and `join` helpers.

Let me know if there's anything else needed to be covered 🙂 

### Example usage

Assume the following helpers:
```rb
def calc(left, op, right, _)
  return unless left.is_a? Numeric
  return unless right.is_a? Numeric

  raise "Invalid operation: #{op}" unless %w(+ - * / ** > >= < <= ==).include?(op)

  eval("#{left} #{op} #{right}")
end

def filter(collection, options)
  func = 
    if options[:equals]
      ->(item) { item == options[:equals] }
    else if options[:starts_with]
      ->(item) { item.starts_with?(options[:starts_with]) }
    else
      ->(item) {}
    end

  collection.select do |item|
    func.call(item.public_send(options[:on]))
  end
end

def first(collection, limit, _)
  collection[0...limit]
end
```

Unlocked use case:

```handlebars
{{#each (first (filter user.badges on="category" equals="achievements"), 5)}}
  <div>...</div> <!-- Display the badge -->
{{/each}}
{{#if (calc user.badges.length "<=" 5)}}
  <!-- Display nothing more -->
{{else}}
  <div>+ {{calc user.badges.length "-" 5}}</div>
{{/if}}
```

### Update ⚠️ 
After some investigation, we found that the use of subexpressions in `each` statements is actually not implemented by this PR. `each` statements currently only accept leaf values that are collections. A follow-up PR will attempt to add support for subexpressions alongside support for helpers returning a specific type of collection or generic collection helpers that can return any type of collection.