### PR TITLE
Call helpers without args in if conditions

### DIFF
--- a/lib/curlybars/node/if_else.rb
+++ b/lib/curlybars/node/if_else.rb
@@ -15,7 +15,7 @@ module Curlybars
 
       def validate(branches)
         [
-          expression.validate(branches, check_type: :not_helper),
+          expression.validate(branches),
           if_template.validate(branches),
           else_template.validate(branches)
         ]

--- a/lib/curlybars/node/unless_else.rb
+++ b/lib/curlybars/node/unless_else.rb
@@ -15,7 +15,7 @@ module Curlybars
 
       def validate(branches)
         [
-          expression.validate(branches, check_type: :not_helper),
+          expression.validate(branches),
           unless_template.validate(branches),
           else_template.validate(branches)
         ]

--- a/lib/curlybars/rendering_support.rb
+++ b/lib/curlybars/rendering_support.rb
@@ -101,7 +101,7 @@ module Curlybars
 
     def cached_call(meth)
       return cached_calls[meth] if cached_calls.key? meth
-      instrument(meth) { cached_calls[meth] = meth.call }
+      instrument(meth) { cached_calls[meth] = meth.call(*arguments_for_signature(meth, [], {})) }
     end
 
     def call(helper, helper_path, helper_position, arguments, options, &block)

--- a/spec/integration/node/helper_spec.rb
+++ b/spec/integration/node/helper_spec.rb
@@ -15,6 +15,18 @@ describe "{{helper context key=value}}" do
       HTML
     end
 
+    it "calls a helper without arguments in an if statement" do
+      template = Curlybars.compile(<<-HBS)
+        {{#if print_args_and_options}}
+          {{print_args_and_options 'first' 'second'}}
+        {{/if}}
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        first, second, key=
+      HTML
+    end
+
     it "passes two arguments and options" do
       template = Curlybars.compile(<<-HBS)
         {{print_args_and_options 'first' 'second' key='value'}}

--- a/spec/integration/node/if_spec.rb
+++ b/spec/integration/node/if_spec.rb
@@ -140,7 +140,7 @@ describe "{{#if}}...{{/if}}" do
       expect(errors).not_to be_empty
     end
 
-    it "validates with errors the helper as condition" do
+    it "validates without errors the helper as condition" do
       dependency_tree = { helper: :helper }
 
       source = <<-HBS
@@ -149,7 +149,7 @@ describe "{{#if}}...{{/if}}" do
 
       errors = Curlybars.validate(dependency_tree, source)
 
-      expect(errors).not_to be_empty
+      expect(errors).to be_empty
     end
   end
 end

--- a/spec/integration/node/unless_else_spec.rb
+++ b/spec/integration/node/unless_else_spec.rb
@@ -96,7 +96,7 @@ describe "{{#unless}}...{{else}}...{{/unless}}" do
       expect(errors).not_to be_empty
     end
 
-    it "validates with errors the helper as condition" do
+    it "validates without errors when using a helper in the condition" do
       dependency_tree = { helper: :helper }
 
       source = <<-HBS
@@ -105,7 +105,7 @@ describe "{{#unless}}...{{else}}...{{/unless}}" do
 
       errors = Curlybars.validate(dependency_tree, source)
 
-      expect(errors).not_to be_empty
+      expect(errors).to be_empty
     end
 
     it "validates with errors the nested unless_template" do


### PR DESCRIPTION
In handlebars, a helper can be called from an `if` statement and previously this was also possible in curlybars.
But due to a bug, [this functionality was disabled](https://github.com/zendesk/curlybars/pull/10) instead of fixed. This, however [raised concerns while implementing subexpressions](https://github.com/zendesk/curlybars/pull/22/files/5c23d868ba2338b9c6e8c2f38d0380527ac021c0#r485015416) and is problematic in the cases we want to "convert" a leaf to a helper behind the scenes.

This PR fixes this issue by invoking the helper will all required arguments as `nil`.
A future improvement is to actually support `if` conditions that [have helpers with arguments](https://github.com/handlebars-lang/handlebars.js/blob/master/spec/builtins.js#L61-L70) - e.g. `{{#if goodbye includeZero=true}}`

