### PR TITLE
Use squiggly heredoc instead of strip_heredoc

### DIFF
--- a/spec/acceptance/application_layout_spec.rb
+++ b/spec/acceptance/application_layout_spec.rb
@@ -2,7 +2,7 @@ describe "Using Curlybars for the application layout", type: :request do
   example "A simple layout view in Curlybars" do
     get '/'
 
-    expect(body).to eq(<<-HTML.strip_heredoc)
+    expect(body).to eq(<<~HTML)
       <html>
       <head>
         <title>Dummy app</title>
@@ -31,7 +31,7 @@ describe "Using Curlybars for the application layout", type: :request do
     example "A simple layout view in Curlybars with html safe logic" do
       get '/articles/1'
 
-      expect(body).to eq(<<-HTML.strip_heredoc)
+      expect(body).to eq(<<~HTML)
         <html>
         <head>
           <title>Dummy app</title>

--- a/spec/acceptance/collection_blocks_spec.rb
+++ b/spec/acceptance/collection_blocks_spec.rb
@@ -8,7 +8,7 @@ describe "Collection blocks", type: :request do
   example "Rendering collections" do
     get '/categories'
 
-    expect(body).to eq(<<-HTML.strip_heredoc)
+    expect(body).to eq(<<~HTML)
       <html>
       <head>
         <title>Dummy app</title>

--- a/spec/acceptance/global_helper_spec.rb
+++ b/spec/acceptance/global_helper_spec.rb
@@ -9,7 +9,7 @@ describe "Collection blocks", type: :request do
   example "Render a global helper" do
     get '/welcome'
 
-    expect(body).to eq(<<-HTML.strip_heredoc)
+    expect(body).to eq(<<~HTML)
       <html>
       <head>
         <title>Dummy app</title>

--- a/spec/curlybars/support/matcher.rb
+++ b/spec/curlybars/support/matcher.rb
@@ -14,7 +14,7 @@ RSpec::Matchers.define(:produce) do |expected|
   end
 
   failure_message do |actual|
-    <<-MESSAGE.strip_heredoc
+    <<~MESSAGE
       Expected
 
         #{normalize(actual.map(&:type))}
@@ -26,7 +26,7 @@ RSpec::Matchers.define(:produce) do |expected|
   end
 
   failure_message_when_negated do |actual|
-    <<-MESSAGE.strip_heredoc
+    <<~MESSAGE
       Expected
 
         #{normalize(actual)}

--- a/spec/curlybars/template_handler_spec.rb
+++ b/spec/curlybars/template_handler_spec.rb
@@ -100,11 +100,11 @@ describe Curlybars::TemplateHandler do
   end
 
   it "strips the `# encoding: *` directive away from the template" do
-    output = render(<<-TEMPLATE.strip_heredoc)
+    output = render(<<~TEMPLATE)
       # encoding: utf-8"
       first line
     TEMPLATE
-    expect(output).to eq(<<-TEMPLATE.strip_heredoc)
+    expect(output).to eq(<<~TEMPLATE)
 
       first line
     TEMPLATE

--- a/spec/dummy/app/helpers/curlybars_helper.rb
+++ b/spec/dummy/app/helpers/curlybars_helper.rb
@@ -8,7 +8,7 @@ module CurlybarsHelper
   end
 
   def date(context, options)
-    html = <<-HTML.strip_heredoc
+    html = <<~HTML
       <time datetime="#{context.strftime('%FT%H:%M:%SZ')}" class="#{options[:class]}">
         #{context.strftime('%B%e, %Y %H:%M')}
       </time>
@@ -24,7 +24,7 @@ module CurlybarsHelper
 
   def input(context, options)
     type = options.fetch(:title, 'text')
-    html = <<-HTML.strip_heredoc
+    html = <<~HTML
       <input name="#{context.name}" id="#{context.id}" type="#{type}" class="#{options['class']}" value="#{context.value}">
     HTML
 

--- a/spec/integration/spec_helper.rb
+++ b/spec/integration/spec_helper.rb
@@ -12,7 +12,7 @@ module IntegrationTest
     end
 
     def date(context, options)
-      html = <<-HTML.strip_heredoc
+      html = <<~HTML
         <time datetime="#{context.strftime('%FT%H:%M:%SZ')}" class="#{options[:class]}">
           #{context.strftime('%B%e, %Y %H:%M')}
         </time>
@@ -28,7 +28,7 @@ module IntegrationTest
 
     def input(context, options)
       type = options.fetch(:title, 'text')
-      html = <<-HTML.strip_heredoc
+      html = <<~HTML
         <input name="#{context.name}" id="#{context.id}" type="#{type}" class="#{options['class']}" value="#{context.value}">
       HTML
 

--- a/spec/integration/support/matcher.rb
+++ b/spec/integration/support/matcher.rb
@@ -10,7 +10,7 @@ RSpec::Matchers.define(:resemble) do |expected|
   end
 
   failure_message do |actual|
-    <<-MESSAGE.strip_heredoc
+    <<~MESSAGE
       Expected
 
         `#{actual}`
@@ -22,7 +22,7 @@ RSpec::Matchers.define(:resemble) do |expected|
   end
 
   failure_message_when_negated do |actual|
-    <<-MESSAGE.strip_heredoc
+    <<~MESSAGE
       Expected
 
         `#{actual}`


### PR DESCRIPTION
`<<~` has been available since Ruby 2.3, so there is no reason to use Rails' `#strip_heredoc` anymore.