### PR TITLE
Drop unused directives from gemspec

### DIFF
--- a/curlybars.gemspec
+++ b/curlybars.gemspec
@@ -45,5 +45,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rubocop-rake", "~> 0.5.0")
   s.add_development_dependency("rubocop-rspec", "~> 2.1.0")
 
-  s.files       = Dir.glob('lib/**/*.rb')
+  s.files = Dir.glob('lib/**/*.rb')
 end

--- a/curlybars.gemspec
+++ b/curlybars.gemspec
@@ -46,6 +46,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rubocop-rspec", "~> 2.1.0")
 
   s.files       = Dir.glob('lib/**/*.rb')
-  s.executables = Dir.glob('bin/**/*').map { |f| File.basename(f) }
-  s.test_files  = Dir.glob('spec/**/*_spec.rb')
 end


### PR DESCRIPTION
This gem exposes no executables, and test_files is not used by RubyGems.org.