### PR TITLE
Release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
-* Add testing with Ruby 2.7
+
+### Curlybars 1.8.0 (November 9, 2022)
+* Add testing with Ruby 2.7, 3.0 & 3.1
 * Add support for Rails 7.0
 
 ### Curlybars 1.7.0 (February 17, 2021)

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.7.0)
+    curlybars (1.8.0)
       actionpack (>= 4.2, < 7.1)
       activesupport (>= 4.2, < 7.1)
       ffi
@@ -35,7 +35,7 @@ GEM
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubis (2.7.0)
-    ffi (1.14.2)
+    ffi (1.15.5)
     filigree (0.4.1)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -134,4 +134,4 @@ DEPENDENCIES
   rubocop-rspec (~> 2.1.0)
 
 BUNDLED WITH
-   2.3.19
+   2.3.22

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.7.0)
+    curlybars (1.8.0)
       actionpack (>= 4.2, < 7.1)
       activesupport (>= 4.2, < 7.1)
       ffi
@@ -35,7 +35,7 @@ GEM
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubis (2.7.0)
-    ffi (1.14.2)
+    ffi (1.15.5)
     filigree (0.4.1)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -133,4 +133,4 @@ DEPENDENCIES
   rubocop-rspec (~> 2.1.0)
 
 BUNDLED WITH
-   2.3.19
+   2.3.22

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.7.0)
+    curlybars (1.8.0)
       actionpack (>= 4.2, < 7.1)
       activesupport (>= 4.2, < 7.1)
       ffi
@@ -35,7 +35,7 @@ GEM
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubi (1.10.0)
-    ffi (1.14.2)
+    ffi (1.15.5)
     filigree (0.4.1)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -133,4 +133,4 @@ DEPENDENCIES
   rubocop-rspec (~> 2.1.0)
 
 BUNDLED WITH
-   2.3.19
+   2.3.22

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.7.0)
+    curlybars (1.8.0)
       actionpack (>= 4.2, < 7.1)
       activesupport (>= 4.2, < 7.1)
       ffi
@@ -35,7 +35,7 @@ GEM
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubi (1.10.0)
-    ffi (1.14.2)
+    ffi (1.15.5)
     filigree (0.4.1)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -133,4 +133,4 @@ DEPENDENCIES
   rubocop-rspec (~> 2.1.0)
 
 BUNDLED WITH
-   2.3.19
+   2.3.22

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.7.0)
+    curlybars (1.8.0)
       actionpack (>= 4.2, < 7.1)
       activesupport (>= 4.2, < 7.1)
       ffi
@@ -36,7 +36,7 @@ GEM
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubi (1.10.0)
-    ffi (1.14.2)
+    ffi (1.15.5)
     filigree (0.4.1)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -135,4 +135,4 @@ DEPENDENCIES
   rubocop-rspec (~> 2.1.0)
 
 BUNDLED WITH
-   2.3.19
+   2.3.22

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.7.0)
+    curlybars (1.8.0)
       actionpack (>= 4.2, < 7.1)
       activesupport (>= 4.2, < 7.1)
       ffi
@@ -134,4 +134,4 @@ DEPENDENCIES
   rubocop-rspec (~> 2.1.0)
 
 BUNDLED WITH
-   2.3.21
+   2.3.22

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.7.0)
+    curlybars (1.8.0)
       actionpack (>= 4.2, < 7.1)
       activesupport (>= 4.2, < 7.1)
       ffi

--- a/lib/curlybars/version.rb
+++ b/lib/curlybars/version.rb
@@ -1,3 +1,3 @@
 module Curlybars
-  VERSION = '1.7.0'.freeze
+  VERSION = '1.8.0'.freeze
 end


### PR DESCRIPTION
Releasing

* Add testing with Ruby 2.7, 3.0 & 3.1 https://github.com/zendesk/curlybars/pull/35
* Add support for Rails 7.0 https://github.com/zendesk/curlybars/pull/34