### PR TITLE
Trigger GitHub Actions workflow on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: push
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   specs-and-rubocop:


### PR DESCRIPTION
The `push` event alone doesn't work when making changed on a forked repository. So now the main workflow runs when a pull request is opened, re-opened or "synchronized" which I assume is when you push new changes.

There is some documentation at [events-that-trigger-workflows#pull_request](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request) and [approving-workflow-runs-from-public-forks](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks)