### PR TITLE
Remove support for Ruby 2.4 and 2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 2.4
           - 2.6
           - 2.7
         gemfile:
@@ -27,10 +26,6 @@ jobs:
         task:
           - rspec
         exclude:
-          - ruby-version: 2.4
-            gemfile: rails6.0
-          - ruby-version: 2.4
-            gemfile: rails6.1
           - ruby-version: 2.6
             gemfile: rails4.2
           - ruby-version: 2.7
@@ -40,7 +35,7 @@ jobs:
           - ruby-version: 2.6
             gemfile: rails7.0
         include:
-          - ruby-version: 2.5
+          - ruby-version: 2.7
             gemfile: rails5.2
             task: rubocop
           - ruby-version: 3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Remove support for Ruby 2.4 and 2.5.
+
 ### Curlybars 1.8.0 (November 9, 2022)
 * Add testing with Ruby 2.7, 3.0 & 3.1
 * Add support for Rails 7.0

--- a/curlybars.gemspec
+++ b/curlybars.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.rdoc_options = ["--charset=UTF-8"]
 
-  s.required_ruby_version = ">= 2.4"
+  s.required_ruby_version = ">= 2.6"
 
   s.add_dependency("actionpack", [">= 4.2", "< 7.1"])
   s.add_dependency("activesupport", [">= 4.2", "< 7.1"])


### PR DESCRIPTION
They are old and deprecated. So is Ruby 2.6, but let's wait just a bit longer.

CI is failing, but I have another PR to fix that. Just wanted to have this “compatibility removal” reviewed separately.