### PR TITLE
[POC] Built in `json` helper

### DIFF
--- a/lib/curlybars/lexer.rb
+++ b/lib/curlybars/lexer.rb
@@ -45,6 +45,8 @@ module Curlybars
     r(/with\b/, :curly) { :WITH }
     r(/else\b/, :curly) { :ELSE }
 
+    r(/json\b/, :curly) { :JSON }
+
     r(/true/, :curly) { [:LITERAL, true] }
     r(/false/, :curly) { [:LITERAL, false] }
     r(/[-+]?\d+/, :curly) { |integer| [:LITERAL, integer.to_i] }

--- a/lib/curlybars/node/json.rb
+++ b/lib/curlybars/node/json.rb
@@ -1,0 +1,25 @@
+module Curlybars
+  module Node
+    Json = Struct.new(:path) do
+      def compile
+        # NOTE: the following is a heredoc string, representing the ruby code fragment
+        # outputted by this node.
+        <<-RUBY
+          buffer.concat(rendering.cached_call(#{path.compile}).to_json)
+        RUBY
+      end
+
+      def validate(branches)
+        # TODO
+      end
+
+      def cache_key
+        # TODO
+        [
+          path.cache_key,
+          self.class.name
+        ].join("/")
+      end
+    end
+  end
+end

--- a/lib/curlybars/parser.rb
+++ b/lib/curlybars/parser.rb
@@ -14,6 +14,7 @@ require 'curlybars/node/with_else'
 require 'curlybars/node/block_helper_else'
 require 'curlybars/node/option'
 require 'curlybars/node/partial'
+require 'curlybars/node/json'
 require 'curlybars/node/output'
 require 'curlybars/node/sub_expression'
 
@@ -160,6 +161,10 @@ module Curlybars
               .template?
             START SLASH WITH END') do |subexpression, with_template, else_template|
         Node::WithElse.new(subexpression, with_template || VOID, else_template || VOID, pos(0))
+      end
+
+      clause('START JSON .path END') do |path|
+        Node::Json.new(path)
       end
 
       clause('START GT .path END') do |path|

--- a/spec/integration/node/json_spec.rb
+++ b/spec/integration/node/json_spec.rb
@@ -1,0 +1,32 @@
+describe "{{helper context key=value}}" do
+  let(:global_helpers_providers) { [] }
+
+  describe "#compile" do
+    let(:post) { double("post") }
+    let(:presenter) { IntegrationTest::Presenter.new(double("view_context"), post: post) }
+
+    it "works with objects" do
+      template = Curlybars.compile(<<-HBS)
+        {{json user}}
+      HBS
+
+      json = CGI.escapeHTML('{"user":{"id":2,"first_name":"Libo","locale":null}}')
+
+      expect(eval(template)).to resemble(<<-HTML)
+        #{json}
+      HTML
+    end
+
+    it "works with collections" do
+      template = Curlybars.compile(<<-HBS)
+        {{json articles}}
+      HBS
+
+      json = CGI.escapeHTML('[{"article":{"id":1,"title":"A1","comment":"\u003cscript\u003ealert(\'bad\')\u003c/script\u003e","body":"This is \u003cstrong\u003eimportant\u003c/strong\u003e!","author":{"id":2,"first_name":"Libo","locale":null}}},{"article":{"id":1,"title":"A2","comment":"\u003cscript\u003ealert(\'bad\')\u003c/script\u003e","body":"This is \u003cstrong\u003eimportant\u003c/strong\u003e!","author":{"id":2,"first_name":"Libo","locale":null}}},{"article":{"id":1,"title":"B1","comment":"\u003cscript\u003ealert(\'bad\')\u003c/script\u003e","body":"This is \u003cstrong\u003eimportant\u003c/strong\u003e!","author":{"id":2,"first_name":"Libo","locale":null}}},{"article":{"id":1,"title":"B2","comment":"\u003cscript\u003ealert(\'bad\')\u003c/script\u003e","body":"This is \u003cstrong\u003eimportant\u003c/strong\u003e!","author":{"id":2,"first_name":"Libo","locale":null}}}]')
+
+      expect(eval(template)).to resemble(<<-HTML)
+        #{json}
+      HTML
+    end
+  end
+end


### PR DESCRIPTION
Currently it is really hard (impossible) to implement a `json` helper that works with any kind of collections and objects.
This PR serves as a POC to explore if this is something we'd want to have as a built in helper such as `if`, `each` or `with`. Implementing `json` as a node should be an easier and more resilient approach then attempting to modify the logic supporting `allowed_methods`.