### PR TITLE
Block usage of 'this' as a generic helper argument

### DIFF
--- a/lib/curlybars/node/path.rb
+++ b/lib/curlybars/node/path.rb
@@ -86,6 +86,12 @@ module Curlybars
         false
       end
 
+      def this?
+        last_path_step = path.split('/').last
+
+        last_path_step.to_sym == :this
+      end
+
       def resolve(branches)
         @value ||= begin
           if Curlybars.global_helpers_dependency_tree.key?(path.to_sym)
@@ -177,6 +183,10 @@ module Curlybars
           message = "`#{path}` resolves to a helper"
           raise Curlybars::Error::Validate.new('is_a_helper', message, position)
         when :anything
+          return unless this?
+
+          message = "`#{path}` cannot resolve to a `this` expression"
+          raise Curlybars::Error::Validate.new('is_this', message, position)
         else
           raise "invalid type `#{check_type}`"
         end

--- a/spec/integration/node/helper_spec.rb
+++ b/spec/integration/node/helper_spec.rb
@@ -271,6 +271,34 @@ describe "{{helper context key=value}}" do
 
         expect(errors).not_to be_empty
       end
+
+      it "raises when used with this as an argumemt" do
+        dependency_tree = {
+          json: [:helper, {}]
+        }
+
+        source = <<-HBS
+          {{json this}}
+        HBS
+
+        errors = Curlybars.validate(dependency_tree, source)
+
+        expect(errors).not_to be_empty
+      end
+
+      it "raises when used with a dotted expression that could resolve to this" do
+        dependency_tree = {
+          article: { title: nil, json: [:helper, {}] }
+        }
+
+        source = <<-HBS
+          {{#with article}} {{json ../this}} {{/with}}
+        HBS
+
+        errors = Curlybars.validate(dependency_tree, source)
+
+        expect(errors).not_to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
When the `this` expression is used as an argument to a generic helper it can have significant performance implications when used along `as_json`.
If `this` matches the top level context and that context is passed on to a generic `json` helper, it will basically lead to the whole presenter tree being accessed (traversed) and serialized.

I'm taking the most restrictive approach in this PR:
- Restrict usage of `this`, or any path that could resolve to `this` (e.g. `../this`) as an argument to **any** generic helper.

This approach can however be a breaking, as existing generic helpers will no longer validate.

Alternative approach:
- Restrict usage of `this`, or any path that could resolve to `this` (e.g. `../this`) as an argument only to the **json** generic helper

This approach would not be a breaking change. However, the problematic `json` helper is not implemented in Curlybars but on the user side, so this validation would no longer work if that helper has another name.

There are more way of going about it but I'd first like to hear your opinion regarding these points first.