### PR TITLE
Fix Rails main tests

### DIFF
--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -9,5 +9,6 @@ module Dummy
   class Application < Rails::Application
     config.cache_store = :memory_store
     config.active_support.to_time_preserves_timezone = :zone
+    config.action_controller.escape_json_responses = false if ActionController::Base.respond_to?(:escape_json_responses)
   end
 end


### PR DESCRIPTION
A config option was added in Rails rails/rails#54643 and immediately deprecated. Because in our test setup we `raise` on deprecations, our rails_main tests were failing.