### PR TITLE
Add runtime partial resolution via providers with safety-bounded rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### Unreleased
+### Curlybars 1.16.0.pre
 
 * Add runtime partial resolution via providers that implement `resolve_partial(name)`, with options and object passing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ### Unreleased
 
+* Add runtime partial resolution via providers that implement `resolve_partial(name)`, with options and object passing
+
 ### Curlybars 1.15.0
 
-* Remove dependency on SortedSet, which doesn't work on Ruby 4.0. If you intend to use Curlybars with Ruby 4.0, you should *not* use an older version than v1.15.0.
+* Remove dependency on SortedSet, which doesn't work on Ruby 4.0. If you intend to use Curlybars with Ruby 4.0, you should *not* use an older version than v1.15.
 
 ### Curlybars 1.14.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    curlybars (1.15.0)
+    curlybars (1.16.0.pre)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       ffi
@@ -215,7 +215,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  curlybars (1.15.0)
+  curlybars (1.16.0.pre)
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,3 +66,27 @@ It is possible to register global helper provider classes via configuration. For
 To enable caching of PORO presenters with `{{#each}}`, set `cache` to a value that responds to `call` with one argument `cache_key` and a block. The callable is expected to return a cached value if the cache key is present, and otherwise call the block and store the result. To integrate with Rails, set this value to `Rails.cache.method(:fetch)`.
 
 By default, caching is not enabled and will simply always invoke the block.
+
+## `partial_provider_class` (default `nil`)
+
+A class responsible for resolving runtime partials. When set, Curlybars will instantiate it with the view context and call `resolve_partial(name)` to look up partial template sources. The method should return a template source string or `nil` if the partial is not found.
+
+```ruby
+Curlybars.configure do |config|
+  config.partial_provider_class = MyPartialProvider
+end
+```
+
+If not set, runtime partial resolution is disabled and only presenter-based partials are available.
+
+## `partial_nesting_limit` (default `3`)
+
+Runtime-resolved partials can invoke other partials, creating nested rendering. To prevent infinite recursion, Curlybars limits the nesting depth. When the limit is reached, the partial renders as an empty string.
+
+```ruby
+Curlybars.configure do |config|
+  config.partial_nesting_limit = 3
+end
+```
+
+**Security note:** Partial sources returned by `resolve_partial` are compiled through the full curlybars pipeline (lexer → parser → AST → code generation) before execution. This means they are subject to the same sandboxing as all other templates: method calls are gated by `allow_methods`, and safety limits (timeout, output size, nesting depth, traversal depth) apply equally.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -357,6 +357,131 @@ Curlybars offers limited support for [subexpressions](https://handlebarsjs.com/g
 {{/each}}
 ```
 
+## Partials
+
+Partials allow you to extract reusable template snippets and include them using the `{{> name}}` syntax. There are two ways to define partials: through presenter methods and through runtime resolution.
+
+### Presenter-based partials
+
+The simplest way to use a partial is to define it as a method on the presenter. Declare the method in `allow_methods` with the `:partial` role, and return the rendered content:
+
+```ruby
+class Invoices::ShowPresenter
+  extend Curlybars::MethodWhitelist
+
+  allow_methods partial: :partial
+end
+```
+
+```hbs
+{{> partial}}
+```
+
+### Runtime-resolved partials
+
+Sometimes you need partials that aren't tied to a specific presenter — for example, reusable UI components shared across multiple templates. Runtime resolution lets a dedicated provider supply template source strings that are compiled and rendered on the fly.
+
+Configure a partial provider class that implements `resolve_partial(name)`. The method receives the partial name as a string and returns either a template source string or `nil` to skip:
+
+```ruby
+class MyPartialProvider
+  PARTIALS = {
+    'card' => '<div class="card">{{title}}</div>',
+    'user_card' => '<span>{{user.first_name}}</span>',
+  }.freeze
+
+  def initialize(context)
+    @context = context
+  end
+
+  def resolve_partial(name)
+    PARTIALS[name.to_s]
+  end
+end
+```
+
+Register the provider via `partial_provider_class`:
+
+```ruby
+Curlybars.configure do |config|
+  config.partial_provider_class = MyPartialProvider
+end
+```
+
+Now you can use these partials in any template:
+
+```hbs
+{{> card title="Hello"}}
+```
+
+This renders:
+
+```html
+<div class="card">Hello</div>
+```
+
+If the provider returns `nil` for a partial name, Curlybars falls back to the presenter-based partial (the `allow_methods partial: :partial` approach).
+
+### Passing options
+
+Options passed to a partial become template variables inside it. Use the familiar `key=value` syntax:
+
+```hbs
+{{> card title="Hello" description="A short summary"}}
+```
+
+Inside the partial template, `{{title}}` and `{{description}}` resolve to the passed values.
+
+### Passing objects
+
+You can pass presenter objects as options too. This is useful for building reusable components that display structured data:
+
+```hbs
+{{> user_card user=user}}
+```
+
+Deep path traversal works as well:
+
+```hbs
+{{> article_section article=article}}
+```
+
+Where the partial template can access nested properties:
+
+```hbs
+<article>{{article.title}} by {{article.author.first_name}}</article>
+```
+
+Inside loops, use `this` to pass the current context:
+
+```hbs
+{{#each comments}}
+  {{> comment_item comment=this}}
+{{/each}}
+```
+
+### Using in loops
+
+Partials work naturally inside `each` blocks. Each iteration can pass loop-scoped values as options:
+
+```hbs
+{{#each items}}
+  {{> card name=first_name}}
+{{/each}}
+```
+
+### Nested partials
+
+Partials can invoke other partials. For example, a `card` partial might include a `user_card` partial inside it. Curlybars tracks nesting depth to prevent infinite recursion — by default, partials can nest up to 3 levels deep (configurable via `partial_nesting_limit`). When the limit is reached, the partial renders as an empty string.
+
+### Error protection
+
+Runtime-resolved partials are designed to fail silently. If the partial source is malformed, an option references an undefined variable, or any other error occurs during rendering, the partial returns an empty string rather than crashing the entire template. Critical errors (timeouts and output-too-long) are still propagated so that safety limits remain enforced.
+
+### Compile-time validation
+
+Runtime-resolved partial names are not validated at compile time. If a partial name has a typo or no provider resolves it, the partial silently renders as an empty string at runtime. Use integration tests to verify that expected partials resolve correctly.
+
 ## Analysis
 
 Curlybars exposes a `.visit` method for traversing a template's parse tree. This can be used to analyze templates without actually rendering them.

--- a/gemfiles/rails7.2.gemfile.lock
+++ b/gemfiles/rails7.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.15.0)
+    curlybars (1.16.0.pre)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       ffi
@@ -223,7 +223,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  curlybars (1.15.0)
+  curlybars (1.16.0.pre)
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/gemfiles/rails8.0.gemfile.lock
+++ b/gemfiles/rails8.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.15.0)
+    curlybars (1.16.0.pre)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       ffi
@@ -219,7 +219,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  curlybars (1.15.0)
+  curlybars (1.16.0.pre)
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/gemfiles/rails8.1.gemfile.lock
+++ b/gemfiles/rails8.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.15.0)
+    curlybars (1.16.0.pre)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       ffi
@@ -217,7 +217,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  curlybars (1.15.0)
+  curlybars (1.16.0.pre)
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/lib/curlybars.rb
+++ b/lib/curlybars.rb
@@ -40,13 +40,10 @@ module Curlybars
     # identifier - The the file name of the template being validated (defaults to `nil`).
     #
     # Returns an array of Curlybars::Error::Validation
-    def validate(dependency_tree, source, identifier = nil, **options)
+    def validate(dependency_tree, source, identifier = nil, partial_resolver: nil, validation_context: nil, **options)
       options.reverse_merge!(
         run_processors: true
       )
-
-      partial_resolver = options.delete(:partial_resolver)
-      validation_context = options.delete(:validation_context)
 
       validation_context ||= ValidationContext.new(partial_resolver: partial_resolver) if partial_resolver
 

--- a/lib/curlybars.rb
+++ b/lib/curlybars.rb
@@ -45,9 +45,14 @@ module Curlybars
         run_processors: true
       )
 
+      partial_resolver = options.delete(:partial_resolver)
+      validation_context = options.delete(:validation_context)
+
+      validation_context ||= ValidationContext.new(partial_resolver: partial_resolver) if partial_resolver
+
       errors = begin
         branches = [dependency_tree]
-        ast(source, identifier, run_processors: options[:run_processors]).validate(branches)
+        ast(source, identifier, run_processors: options[:run_processors]).validate(branches, context: validation_context)
       rescue Curlybars::Error::Base => ast_error
         [ast_error]
       end
@@ -159,8 +164,10 @@ require 'curlybars/error/compile'
 require 'curlybars/error/validate'
 require 'curlybars/error/render'
 require 'curlybars/template_handler'
+require 'curlybars/validation_context'
 require 'curlybars/railtie' if defined?(Rails)
 require 'curlybars/presenter'
 require 'curlybars/method_whitelist'
+require 'curlybars/partial_presenter'
 require 'curlybars/visitor'
 require 'curlybars/path_finder'

--- a/lib/curlybars/configuration.rb
+++ b/lib/curlybars/configuration.rb
@@ -16,7 +16,7 @@ module Curlybars
   end
 
   class Configuration
-    attr_accessor :presenters_namespace, :nesting_limit, :traversing_limit, :output_limit, :rendering_timeout, :custom_processors, :compiler_transformers, :global_helpers_provider_classes, :cache
+    attr_accessor :presenters_namespace, :nesting_limit, :traversing_limit, :output_limit, :rendering_timeout, :custom_processors, :compiler_transformers, :global_helpers_provider_classes, :cache, :partial_nesting_limit, :partial_provider_class
 
     def initialize
       @presenters_namespace = ''
@@ -28,6 +28,8 @@ module Curlybars
       @compiler_transformers = []
       @global_helpers_provider_classes = []
       @cache = ->(key, &block) { block.call }
+      @partial_nesting_limit = 3
+      @partial_provider_class = nil
     end
   end
 end

--- a/lib/curlybars/node/block_helper_else.rb
+++ b/lib/curlybars/node/block_helper_else.rb
@@ -64,7 +64,7 @@ module Curlybars
         RUBY
       end
 
-      def validate(branches)
+      def validate(branches, context: nil)
         check_open_and_close_elements(helper, helperclose, Curlybars::Error::Validate)
 
         if helper.leaf?(branches)
@@ -74,8 +74,8 @@ module Curlybars
           end
         elsif helper.helper?(branches)
           [
-            helper_template.validate(branches),
-            else_template.validate(branches),
+            helper_template.validate(branches, context: context),
+            else_template.validate(branches, context: context),
             arguments.map { |argument| argument.validate_as_value(branches) },
             options.map { |option| option.validate(branches) }
           ]
@@ -85,8 +85,8 @@ module Curlybars
             Curlybars::Error::Validate.new('invalid_signature', message, helper.position)
           else
             [
-              helper_template.validate(branches),
-              else_template.validate(branches),
+              helper_template.validate(branches, context: context),
+              else_template.validate(branches, context: context),
               arguments.map { |argument| argument.validate(branches, check_type: :anything) },
               options.map { |option| option.validate(branches) }
             ]

--- a/lib/curlybars/node/boolean.rb
+++ b/lib/curlybars/node/boolean.rb
@@ -9,7 +9,7 @@ module Curlybars
         RUBY
       end
 
-      def validate(branches)
+      def validate(branches, context: nil)
         # Nothing to validate here.
       end
 

--- a/lib/curlybars/node/each_else.rb
+++ b/lib/curlybars/node/each_else.rb
@@ -36,18 +36,18 @@ module Curlybars
         RUBY
       end
 
-      def validate(branches)
+      def validate(branches, context: nil)
         resolved = path.resolve_and_check!(branches, check_type: :collectionlike)
         sub_tree = resolved.first
 
         each_template_errors = begin
           branches.push(sub_tree)
-          each_template.validate(branches)
+          each_template.validate(branches, context: context)
         ensure
           branches.pop
         end
 
-        else_template_errors = else_template.validate(branches)
+        else_template_errors = else_template.validate(branches, context: context)
 
         [
           each_template_errors,

--- a/lib/curlybars/node/if_else.rb
+++ b/lib/curlybars/node/if_else.rb
@@ -13,11 +13,11 @@ module Curlybars
         RUBY
       end
 
-      def validate(branches)
+      def validate(branches, context: nil)
         [
           expression.validate(branches),
-          if_template.validate(branches),
-          else_template.validate(branches)
+          if_template.validate(branches, context: context),
+          else_template.validate(branches, context: context)
         ]
       end
 

--- a/lib/curlybars/node/item.rb
+++ b/lib/curlybars/node/item.rb
@@ -14,8 +14,8 @@ module Curlybars
         RUBY
       end
 
-      def validate(branches)
-        item.validate(branches)
+      def validate(branches, context: nil)
+        item.validate(branches, context: context)
       rescue Curlybars::Error::Validate => path_error
         path_error
       end

--- a/lib/curlybars/node/literal.rb
+++ b/lib/curlybars/node/literal.rb
@@ -9,7 +9,7 @@ module Curlybars
         RUBY
       end
 
-      def validate(branches, check_type: :anything)
+      def validate(branches, check_type: :anything, context: nil)
         # Nothing to validate here.
       end
 

--- a/lib/curlybars/node/output.rb
+++ b/lib/curlybars/node/output.rb
@@ -9,8 +9,8 @@ module Curlybars
         RUBY
       end
 
-      def validate(branches)
-        value.validate(branches)
+      def validate(branches, context: nil)
+        value.validate(branches, context: context)
       end
 
       def cache_key

--- a/lib/curlybars/node/partial.rb
+++ b/lib/curlybars/node/partial.rb
@@ -1,21 +1,72 @@
 module Curlybars
   module Node
-    Partial = Struct.new(:path) do
+    Partial = Struct.new(:path, :options, :position) do
       def compile
+        compiled_options = options.map do |option|
+          "options.merge!(#{option.compile})"
+        end.join("\n")
+
         # NOTE: the following is a heredoc string, representing the ruby code fragment
         # outputted by this node.
         <<-RUBY
-          buffer.concat(rendering.cached_call(#{path.compile}).to_s)
+          options = ::ActiveSupport::HashWithIndifferentAccess.new
+          #{compiled_options}
+
+          partial_source = rendering.resolve_partial(#{path.path.inspect})
+          if partial_source
+            buffer.concat(rendering.render_partial(partial_source, #{path.path.inspect}, options).to_s)
+          else
+            buffer.concat(rendering.cached_call(#{path.compile}).to_s)
+          end
         RUBY
       end
 
-      def validate(branches)
-        path.validate(branches, check_type: :partial)
+      def validate(branches, context: nil)
+        # Validate option expressions in current scope
+        errors = options.flat_map { |option| option.expression.validate(branches) }
+
+        return errors unless context&.partial_resolver
+
+        partial_source = begin
+          context.partial_resolver.call(path.path)
+        rescue StandardError
+          nil
+        end
+
+        if partial_source
+          options_tree = options.each_with_object({}) do |option, tree|
+            expr = option.expression
+            tree[option.key.to_sym] = if expr.respond_to?(:resolve)
+              begin
+                expr.resolve(branches)
+              rescue Curlybars::Error::Validate
+                nil
+              end
+            end
+          end
+
+          if context.within_depth_limit?
+            partial_errors = Curlybars.validate(
+              options_tree,
+              partial_source,
+              :"partials/#{path.path}",
+              validation_context: context.increment_depth,
+              run_processors: false
+            )
+            errors.concat(partial_errors)
+          end
+        else
+          errors.concat(Array(path.validate(branches, check_type: :partial)))
+        end
+
+        errors
       end
 
       def cache_key
         [
           path.cache_key,
+          options.map(&:cache_key).join("/"),
+          position&.file_name,
           self.class.name
         ].join("/")
       end

--- a/lib/curlybars/node/partial.rb
+++ b/lib/curlybars/node/partial.rb
@@ -45,7 +45,7 @@ module Curlybars
             end
           end
 
-          if context.within_depth_limit?
+          if context.valid?
             partial_errors = Curlybars.validate(
               options_tree,
               partial_source,
@@ -64,11 +64,9 @@ module Curlybars
 
       def cache_key
         [
-          path.cache_key,
-          options.map(&:cache_key).join("/"),
-          position&.file_name,
-          self.class.name
-        ].join("/")
+          path,
+          options
+        ].flatten.map(&:cache_key).push(position&.file_name, self.class.name).join("/")
       end
     end
   end

--- a/lib/curlybars/node/path.rb
+++ b/lib/curlybars/node/path.rb
@@ -16,7 +16,7 @@ module Curlybars
         validate(branches, check_type: :leaf)
       end
 
-      def validate(branches, check_type: :anything)
+      def validate(branches, check_type: :anything, context: nil)
         resolve_and_check!(branches, check_type: check_type)
         []
       rescue Curlybars::Error::Validate => path_error

--- a/lib/curlybars/node/root.rb
+++ b/lib/curlybars/node/root.rb
@@ -15,9 +15,9 @@ module Curlybars
             #{position.file_name.inspect},
             global_helpers_providers,
             ::Curlybars.configuration.cache,
-            has_rendering_context ? rendering_context[:start_time] : nil,
-            has_rendering_context ? rendering_context[:depth] : 0,
-            partial_provider
+            start_time: has_rendering_context ? rendering_context[:start_time] : nil,
+            depth: has_rendering_context ? rendering_context[:depth] : 0,
+            partial_provider: partial_provider
           )
           buffer = ::Curlybars::SafeBuffer.new
           #{template.compile}

--- a/lib/curlybars/node/root.rb
+++ b/lib/curlybars/node/root.rb
@@ -7,13 +7,17 @@ module Curlybars
         <<-RUBY
           contexts = [presenter]
           variables = [{}]
+          has_rendering_context = defined?(rendering_context)
           rendering = ::Curlybars::RenderingSupport.new(
             ::Curlybars.configuration.rendering_timeout,
             contexts,
             variables,
             #{position.file_name.inspect},
             global_helpers_providers,
-            ::Curlybars.configuration.cache
+            ::Curlybars.configuration.cache,
+            has_rendering_context ? rendering_context[:start_time] : nil,
+            has_rendering_context ? rendering_context[:depth] : 0,
+            partial_provider
           )
           buffer = ::Curlybars::SafeBuffer.new
           #{template.compile}
@@ -21,8 +25,8 @@ module Curlybars
         RUBY
       end
 
-      def validate(branches)
-        template.validate(branches)
+      def validate(branches, context: nil)
+        template.validate(branches, context: context)
       end
     end
   end

--- a/lib/curlybars/node/string.rb
+++ b/lib/curlybars/node/string.rb
@@ -9,7 +9,7 @@ module Curlybars
         RUBY
       end
 
-      def validate(branches)
+      def validate(branches, context: nil)
         # Nothing to validate here.
       end
 

--- a/lib/curlybars/node/sub_expression.rb
+++ b/lib/curlybars/node/sub_expression.rb
@@ -46,7 +46,7 @@ module Curlybars
         validate(branches, check_type: check_type)
       end
 
-      def validate(branches, check_type: :anything)
+      def validate(branches, check_type: :anything, context: nil)
         [
           helper.validate(branches, check_type: :helper),
           arguments.map { |argument| argument.validate_as_value(branches) },

--- a/lib/curlybars/node/template.rb
+++ b/lib/curlybars/node/template.rb
@@ -20,8 +20,8 @@ module Curlybars
         RUBY
       end
 
-      def validate(branches)
-        items.map { |item| item.validate(branches) }
+      def validate(branches, context: nil)
+        items.map { |item| item.validate(branches, context: context) }
       end
 
       def cache_key

--- a/lib/curlybars/node/text.rb
+++ b/lib/curlybars/node/text.rb
@@ -9,7 +9,7 @@ module Curlybars
         RUBY
       end
 
-      def validate(branches)
+      def validate(branches, context: nil)
         # Nothing to validate here.
       end
 

--- a/lib/curlybars/node/unless_else.rb
+++ b/lib/curlybars/node/unless_else.rb
@@ -13,11 +13,11 @@ module Curlybars
         RUBY
       end
 
-      def validate(branches)
+      def validate(branches, context: nil)
         [
           expression.validate(branches),
-          unless_template.validate(branches),
-          else_template.validate(branches)
+          unless_template.validate(branches, context: context),
+          else_template.validate(branches, context: context)
         ]
       end
 

--- a/lib/curlybars/node/variable.rb
+++ b/lib/curlybars/node/variable.rb
@@ -15,7 +15,7 @@ module Curlybars
         RUBY
       end
 
-      def validate(branches, check_type: :anything)
+      def validate(branches, check_type: :anything, context: nil)
         # Nothing to validate here.
       end
 

--- a/lib/curlybars/node/with_else.rb
+++ b/lib/curlybars/node/with_else.rb
@@ -23,16 +23,16 @@ module Curlybars
         RUBY
       end
 
-      def validate(branches)
+      def validate(branches, context: nil)
         sub_tree = path.resolve_and_check!(branches, check_type: :presenterlike)
         with_template_errors = begin
           branches.push(sub_tree)
-          with_template.validate(branches)
+          with_template.validate(branches, context: context)
         ensure
           branches.pop
         end
 
-        else_template_errors = else_template.validate(branches)
+        else_template_errors = else_template.validate(branches, context: context)
 
         [
           with_template_errors,

--- a/lib/curlybars/parser.rb
+++ b/lib/curlybars/parser.rb
@@ -162,8 +162,8 @@ module Curlybars
         Node::WithElse.new(subexpression, with_template || VOID, else_template || VOID, pos(0))
       end
 
-      clause('START GT .path END') do |path|
-        Node::Partial.new(path)
+      clause('START GT .path .options? END') do |path, options|
+        Node::Partial.new(path, options || [], pos(0))
       end
     end
 
@@ -210,7 +210,7 @@ module Curlybars
         # Nothing to compile.
       end
 
-      def validate(branches)
+      def validate(branches, context: nil)
         [] # Nothing to validate.
       end
 

--- a/lib/curlybars/partial_presenter.rb
+++ b/lib/curlybars/partial_presenter.rb
@@ -1,0 +1,26 @@
+module Curlybars
+  class PartialPresenter
+    extend MethodWhitelist
+
+    def initialize(_context, data = {})
+      @_safe_keys = Set.new
+      data.symbolize_keys.each do |key, value|
+        next if respond_to?(key, true)
+
+        define_singleton_method(key) { value }
+        @_safe_keys.add(key)
+      end
+      @_safe_keys.freeze
+    end
+
+    # Subclasses that call allow_methods get their allowed_methods via super,
+    # which includes these dynamic data keys.
+    def allowed_methods
+      @_safe_keys.to_a
+    end
+
+    def allows_method?(method)
+      @_safe_keys.include?(method.to_sym)
+    end
+  end
+end

--- a/lib/curlybars/rendering_support.rb
+++ b/lib/curlybars/rendering_support.rb
@@ -1,14 +1,17 @@
 module Curlybars
   class RenderingSupport
-    def initialize(timeout, contexts, variables, file_name, global_helpers_providers = [], cache = ->(key, &block) { block.call })
+    def initialize(timeout, contexts, variables, file_name, global_helpers_providers = [], cache = ->(key, &block) { block.call }, start_time = nil, depth = 0, partial_provider = nil)
       @timeout = timeout
-      @start_time = Time.now
+      @start_time = start_time || Time.now
+      @depth = depth
 
       @contexts = contexts
       @variables = variables
       @file_name = file_name
       @cached_calls = {}
       @cache = cache
+      @global_helpers_providers = global_helpers_providers
+      @partial_provider = partial_provider
 
       @global_helpers = {}
 
@@ -176,9 +179,42 @@ module Curlybars
       end
     end
 
+    def resolve_partial(name)
+      return nil unless @partial_provider
+
+      source = @partial_provider.resolve_partial(name)
+      return nil unless source
+
+      raise TypeError, "resolve_partial must return a String, got #{source.class}" unless source.is_a?(String)
+
+      source
+    end
+
+    def render_partial(source, name, options)
+      return "" if @depth >= ::Curlybars.configuration.partial_nesting_limit
+
+      compiled = ::Curlybars.compile(source, "partial:#{name}")
+
+      eval_source = <<-RUBY
+        rendering_context = { start_time: @start_time, depth: @depth + 1 }
+        presenter = ::Curlybars::PartialPresenter.new(nil, options)
+        global_helpers_providers = @global_helpers_providers
+        partial_provider = @partial_provider
+        #{compiled}
+      RUBY
+
+      eval(eval_source) # rubocop:disable Security/Eval -- eval is the established compilation pattern for the whole engine
+    rescue Curlybars::Error::Render => e
+      raise if e.id == 'render.timeout' || e.id == 'render.output_too_long'
+
+      "".html_safe
+    rescue StandardError
+      "".html_safe
+    end
+
     private
 
-    attr_reader :contexts, :variables, :cached_calls, :file_name, :global_helpers, :start_time, :timeout, :cache
+    attr_reader :contexts, :variables, :cached_calls, :file_name, :global_helpers, :start_time, :timeout, :cache, :depth, :partial_provider
 
     def instrument(meth, &)
       # Instruments only callables that give enough details (eg. methods)

--- a/lib/curlybars/rendering_support.rb
+++ b/lib/curlybars/rendering_support.rb
@@ -1,6 +1,6 @@
 module Curlybars
   class RenderingSupport
-    def initialize(timeout, contexts, variables, file_name, global_helpers_providers = [], cache = ->(key, &block) { block.call }, start_time = nil, depth = 0, partial_provider = nil)
+    def initialize(timeout, contexts, variables, file_name, global_helpers_providers = [], cache = ->(key, &block) { block.call }, start_time: nil, depth: 0, partial_provider: nil)
       @timeout = timeout
       @start_time = start_time || Time.now
       @depth = depth
@@ -180,9 +180,9 @@ module Curlybars
     end
 
     def resolve_partial(name)
-      return nil unless @partial_provider
+      return nil unless partial_provider
 
-      source = @partial_provider.resolve_partial(name)
+      source = partial_provider.resolve_partial(name)
       return nil unless source
 
       raise TypeError, "resolve_partial must return a String, got #{source.class}" unless source.is_a?(String)
@@ -191,7 +191,7 @@ module Curlybars
     end
 
     def render_partial(source, name, options)
-      return "" if @depth >= ::Curlybars.configuration.partial_nesting_limit
+      return "" if depth >= ::Curlybars.configuration.partial_nesting_limit
 
       compiled = ::Curlybars.compile(source, "partial:#{name}")
 
@@ -207,9 +207,9 @@ module Curlybars
     rescue Curlybars::Error::Render => e
       raise if e.id == 'render.timeout' || e.id == 'render.output_too_long'
 
-      "".html_safe
+      ""
     rescue StandardError
-      "".html_safe
+      ""
     end
 
     private

--- a/lib/curlybars/template_handler.rb
+++ b/lib/curlybars/template_handler.rb
@@ -72,6 +72,9 @@ module Curlybars
           provider_classes = ::Curlybars.configuration.global_helpers_provider_classes
           global_helpers_providers = provider_classes.map { |klass| klass.new(self) }
 
+          partial_provider_class = ::Curlybars.configuration.partial_provider_class
+          partial_provider = partial_provider_class&.new(self)
+
           presenter = ::#{presenter_class}.new(self, options)
           presenter.setup!
 

--- a/lib/curlybars/validation_context.rb
+++ b/lib/curlybars/validation_context.rb
@@ -7,7 +7,7 @@ module Curlybars
       @depth = depth
     end
 
-    def within_depth_limit?
+    def valid?
       depth < Curlybars.configuration.partial_nesting_limit
     end
 

--- a/lib/curlybars/validation_context.rb
+++ b/lib/curlybars/validation_context.rb
@@ -1,0 +1,18 @@
+module Curlybars
+  class ValidationContext
+    attr_reader :partial_resolver, :depth
+
+    def initialize(partial_resolver: nil, depth: 0)
+      @partial_resolver = partial_resolver
+      @depth = depth
+    end
+
+    def within_depth_limit?
+      depth < Curlybars.configuration.partial_nesting_limit
+    end
+
+    def increment_depth
+      self.class.new(partial_resolver: partial_resolver, depth: depth + 1)
+    end
+  end
+end

--- a/lib/curlybars/version.rb
+++ b/lib/curlybars/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Curlybars
-  VERSION = '1.15.0'
+  VERSION = '1.16.0.pre'
 end

--- a/lib/curlybars/visitor.rb
+++ b/lib/curlybars/visitor.rb
@@ -63,6 +63,7 @@ module Curlybars
 
     def visit_partial(node)
       visit(node.path)
+      node.options.each { |opt| visit(opt) }
     end
 
     def visit_path(_node)

--- a/spec/curlybars/partial_presenter_spec.rb
+++ b/spec/curlybars/partial_presenter_spec.rb
@@ -1,0 +1,129 @@
+describe Curlybars::PartialPresenter do
+  subject(:presenter) { described_class.new(nil, data) }
+
+  let(:data) { { title: "Hello", "body" => "World" } }
+
+  describe "#allows_method?" do
+    it "returns true for keys present in data" do
+      expect(presenter.allows_method?(:title)).to be true
+    end
+
+    it "returns true for string keys symbolized" do
+      expect(presenter.allows_method?(:body)).to be true
+    end
+
+    it "returns false for keys not in data" do
+      expect(presenter.allows_method?(:missing)).to be false
+    end
+  end
+
+  describe "singleton methods" do
+    it "returns the value for a known key" do
+      expect(presenter.title).to eq("Hello")
+    end
+
+    it "returns the value for a string key (symbolized)" do
+      expect(presenter.body).to eq("World")
+    end
+
+    it "raises NoMethodError for unknown keys" do
+      expect { presenter.missing }.to raise_error(NoMethodError)
+    end
+
+    it "returns a Method object via #method" do
+      expect(presenter.method(:title)).to be_a(Method)
+    end
+
+    it "returns the correct value when calling the Method object" do
+      expect(presenter.method(:title).call).to eq("Hello")
+    end
+  end
+
+  describe "#respond_to?" do
+    it "returns true for known keys" do
+      expect(presenter.respond_to?(:title)).to be true
+    end
+
+    it "returns false for unknown keys" do
+      expect(presenter.respond_to?(:missing)).to be false
+    end
+  end
+
+  describe "with empty data" do
+    let(:data) { {} }
+
+    it "allows no methods" do
+      expect(presenter.allows_method?(:anything)).to be false
+    end
+  end
+
+  describe "existing methods are not overridden" do
+    let(:data) { { class: "hacked", send: "evil", title: "Safe" } }
+
+    it "does not override :class" do
+      expect(presenter.class).to eq(Curlybars::PartialPresenter)
+    end
+
+    it "does not override :send" do
+      expect(presenter.send(:class)).to eq(Curlybars::PartialPresenter)
+    end
+
+    it "still defines keys that don't collide" do
+      expect(presenter.title).to eq("Safe")
+    end
+
+    it "excludes :class from allowed_methods" do
+      expect(presenter.allowed_methods).not_to include(:class)
+    end
+
+    it "excludes :send from allowed_methods" do
+      expect(presenter.allowed_methods).not_to include(:send)
+    end
+
+    it "includes non-colliding keys in allowed_methods" do
+      expect(presenter.allowed_methods).to include(:title)
+    end
+
+    it "returns false for allows_method?(:class)" do
+      expect(presenter.allows_method?(:class)).to be false
+    end
+
+    it "returns false for allows_method?(:send)" do
+      expect(presenter.allows_method?(:send)).to be false
+    end
+  end
+
+  describe "subclass with allow_methods" do
+    let(:subclass) do
+      Class.new(described_class) do
+        extend Curlybars::MethodWhitelist
+
+        allow_methods :site_name
+
+        def site_name
+          "TestSite"
+        end
+      end
+    end
+
+    it "recognizes declared methods via allows_method?" do
+      instance = subclass.new(nil, { title: "Hi" })
+      expect(instance.allows_method?(:site_name)).to be true
+    end
+
+    it "recognizes dynamic data keys via allows_method?" do
+      instance = subclass.new(nil, { title: "Hi" })
+      expect(instance.allows_method?(:title)).to be true
+    end
+
+    it "returns dynamic data values" do
+      instance = subclass.new(nil, { title: "Hi" })
+      expect(instance.title).to eq("Hi")
+    end
+
+    it "returns declared method values" do
+      instance = subclass.new(nil, {})
+      expect(instance.site_name).to eq("TestSite")
+    end
+  end
+end

--- a/spec/integration/cache_spec.rb
+++ b/spec/integration/cache_spec.rb
@@ -24,6 +24,7 @@ describe "caching" do
   end
 
   let(:global_helpers_providers) { [] }
+  let(:partial_provider) { nil }
   let(:presenter) { IntegrationTest::Presenter.new(double("view_context")) }
   let(:cache) { dummy_cache.new }
 

--- a/spec/integration/comment_spec.rb
+++ b/spec/integration/comment_spec.rb
@@ -2,6 +2,7 @@ describe "{{!-- --}} and {{! }}" do
   let(:post) { double("post") }
   let(:presenter) { IntegrationTest::Presenter.new(double("view_context"), post: post) }
   let(:global_helpers_providers) { [] }
+  let(:partial_provider) { nil }
 
   it "ignores one line comment" do
     template = Curlybars.compile(<<-HBS)

--- a/spec/integration/exception_spec.rb
+++ b/spec/integration/exception_spec.rb
@@ -2,6 +2,7 @@ describe "Exception reporting" do
   let(:post) { double("post") }
   let(:presenter) { IntegrationTest::Presenter.new(double("view_context"), post: post) }
   let(:global_helpers_providers) { [] }
+  let(:partial_provider) { nil }
 
   it "Throw Curlybars::Error::Lex in case of a lex error occurs" do
     expect do

--- a/spec/integration/json_spec.rb
+++ b/spec/integration/json_spec.rb
@@ -1,5 +1,6 @@
 describe "{{json arg1}}" do
   let(:global_helpers_providers) { [IntegrationTest::GlobalHelperProvider.new] }
+  let(:partial_provider) { nil }
 
   describe "#compile" do
     let(:presenter) { IntegrationTest::Presenter.new(double("view_context")) }

--- a/spec/integration/node/block_helper_else_spec.rb
+++ b/spec/integration/node/block_helper_else_spec.rb
@@ -1,5 +1,6 @@
 describe "{{#helper arg1 arg2 ... key=value ...}}...<{{else}}>...{{/helper}}" do
   let(:global_helpers_providers) { [IntegrationTest::GlobalHelperProvider.new] }
+  let(:partial_provider) { nil }
 
   describe "#compile" do
     let(:post) { double("post") }

--- a/spec/integration/node/each_else_spec.rb
+++ b/spec/integration/node/each_else_spec.rb
@@ -1,5 +1,6 @@
 describe "{{#each collection}}...{{else}}...{{/each}}" do
   let(:global_helpers_providers) { [IntegrationTest::GlobalHelperProvider.new] }
+  let(:partial_provider) { nil }
 
   describe "#compile" do
     let(:post) { double("post") }

--- a/spec/integration/node/each_spec.rb
+++ b/spec/integration/node/each_spec.rb
@@ -1,5 +1,6 @@
 describe "{{#each collection}}...{{/each}}" do
   let(:global_helpers_providers) { [] }
+  let(:partial_provider) { nil }
 
   describe "#compile" do
     let(:post) { double("post") }

--- a/spec/integration/node/escape_spec.rb
+++ b/spec/integration/node/escape_spec.rb
@@ -2,6 +2,7 @@ describe '`\` as an escaping character' do
   let(:post) { double("post") }
   let(:presenter) { IntegrationTest::Presenter.new(double("view_context"), post: post) }
   let(:global_helpers_providers) { [] }
+  let(:partial_provider) { nil }
 
   it "escapes `{`" do
     template = Curlybars.compile(<<-HBS)

--- a/spec/integration/node/helper_spec.rb
+++ b/spec/integration/node/helper_spec.rb
@@ -1,5 +1,6 @@
 describe "{{helper context key=value}}" do
   let(:global_helpers_providers) { [] }
+  let(:partial_provider) { nil }
 
   describe "#compile" do
     let(:post) { double("post") }

--- a/spec/integration/node/if_else_spec.rb
+++ b/spec/integration/node/if_else_spec.rb
@@ -1,5 +1,6 @@
 describe "{{#if}}...{{else}}...{{/if}}" do
   let(:global_helpers_providers) { [] }
+  let(:partial_provider) { nil }
 
   describe "#compile" do
     let(:post) { double("post") }

--- a/spec/integration/node/if_spec.rb
+++ b/spec/integration/node/if_spec.rb
@@ -1,5 +1,6 @@
 describe "{{#if}}...{{/if}}" do
   let(:global_helpers_providers) { [] }
+  let(:partial_provider) { nil }
 
   describe "#compile" do
     let(:post) { double("post") }

--- a/spec/integration/node/output_spec.rb
+++ b/spec/integration/node/output_spec.rb
@@ -1,5 +1,6 @@
 describe '{{value}}' do
   let(:global_helpers_providers) { [] }
+  let(:partial_provider) { nil }
 
   describe "#compile" do
     let(:post) { double("post") }

--- a/spec/integration/node/partial_spec.rb
+++ b/spec/integration/node/partial_spec.rb
@@ -140,6 +140,14 @@ describe "{{> partial}}" do
       HTML
     end
 
+    it "renders a resolved partial with no options" do
+      template = Curlybars.compile(<<-HBS)
+        {{> nested_inner}}
+      HBS
+
+      expect(eval(template)).to resemble("inner")
+    end
+
     it "renders empty string when option is missing (no crash)" do
       template = Curlybars.compile(<<-HBS)
         {{> user_card}}

--- a/spec/integration/node/partial_spec.rb
+++ b/spec/integration/node/partial_spec.rb
@@ -1,5 +1,6 @@
 describe "{{> partial}}" do
   let(:global_helpers_providers) { [] }
+  let(:partial_provider) { nil }
 
   describe "#compile" do
     let(:post) { double("post") }
@@ -24,36 +25,512 @@ describe "{{> partial}}" do
     end
   end
 
+  describe "#compile with resolver" do
+    let(:post) { double("post") }
+    let(:presenter) { IntegrationTest::Presenter.new(double("view_context"), post: post) }
+    let(:partial_provider) { IntegrationTest::PartialResolvingProvider.new }
+
+    it "renders a resolved partial template" do
+      template = Curlybars.compile(<<-HBS)
+        {{> card title="Hello"}}
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        <div class="card">Hello</div>
+      HTML
+    end
+
+    it "passes options to the partial as template variables" do
+      template = Curlybars.compile(<<-HBS)
+        {{> card title="World"}}
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        <div class="card">World</div>
+      HTML
+    end
+
+    it "renders nested partials" do
+      template = Curlybars.compile(<<-HBS)
+        {{> nested_outer}}
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        inner
+      HTML
+    end
+
+    it "enforces nesting depth limit" do
+      Curlybars.configuration.partial_nesting_limit = 3
+
+      template = Curlybars.compile(<<-HBS)
+        {{> deeply_nested}}
+      HBS
+
+      expect(eval(template)).to resemble("")
+    ensure
+      Curlybars.reset
+    end
+
+    it "falls back to presenter method when resolver returns nil" do
+      template = Curlybars.compile(<<-HBS)
+        {{> partial}}
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        partial
+      HTML
+    end
+
+    it "passes a presenter as an option" do
+      template = Curlybars.compile(<<-HBS)
+        {{> user_card user=user}}
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        <span>Libo</span>
+      HTML
+    end
+
+    it "passes a presenter via `this` inside #with" do
+      template = Curlybars.compile(<<-HBS)
+        {{#with user}}{{> user_card user=this}}{{/with}}
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        <span>Libo</span>
+      HTML
+    end
+
+    it "supports deep traversal inside a partial" do
+      template = Curlybars.compile(<<-HBS)
+        {{> article_section article=article}}
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        <article>The Prince by Nicolò</article>
+      HTML
+    end
+
+    it "passes values from #each via option" do
+      template = Curlybars.compile(<<-HBS)
+        {{#each two_elements}}{{> simple_name name=first_name}}{{/each}}
+      HBS
+
+      expect(eval(template)).to resemble("LiboLibo")
+    end
+
+    it "passes a dotted path as an option" do
+      template = Curlybars.compile(<<-HBS)
+        {{> user_card user=article.author}}
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        <span>Nicolò</span>
+      HTML
+    end
+
+    it "passes a user presenter as comment option" do
+      template = Curlybars.compile(<<-HBS)
+        {{> comment_item comment=user}}
+      HBS
+
+      expect(eval(template)).to resemble(<<-HTML)
+        <li>Libo</li>
+      HTML
+    end
+
+    it "renders empty string when option is missing (no crash)" do
+      template = Curlybars.compile(<<-HBS)
+        {{> user_card}}
+      HBS
+
+      expect(eval(template)).to resemble("")
+    end
+
+    it "renders empty string for malformed partial source" do
+      template = Curlybars.compile(<<-HBS)
+        {{> malformed}}
+      HBS
+
+      expect(eval(template)).to resemble("")
+    end
+
+    it "renders empty string when referencing undefined data in partial" do
+      template = Curlybars.compile(<<-HBS)
+        {{> missing_ref}}
+      HBS
+
+      expect(eval(template)).to resemble("")
+    end
+
+    it "propagates timeout error from nested partial (not swallowed)" do
+      Curlybars.configuration.rendering_timeout = 10
+
+      template = Curlybars.compile(<<-HBS)
+        {{> nested_outer}}
+      HBS
+
+      rendering_context = { start_time: Time.now - 20, depth: 0 } # rubocop:disable Lint/UselessAssignment -- read by eval'd template via defined?(rendering_context)
+
+      expect { eval(template) }.to raise_error(Curlybars::Error::Render).with_message(/too long/)
+    ensure
+      Curlybars.reset
+    end
+
+    it "propagates parent start_time to child partials via rendering_context" do
+      Curlybars.configuration.rendering_timeout = 10
+
+      template = Curlybars.compile(<<-HBS)
+        {{> card title="timeout"}}
+      HBS
+
+      rendering_context = { start_time: Time.now - 20, depth: 0 } # rubocop:disable Lint/UselessAssignment -- read by eval'd template via defined?(rendering_context)
+
+      expect { eval(template) }.to raise_error(Curlybars::Error::Render)
+    ensure
+      Curlybars.reset
+    end
+
+    context "with global helper provider" do
+      let(:global_helpers_providers) { [IntegrationTest::GlobalHelperProvider.new] }
+
+      it "can access global helpers inside a partial" do
+        template = Curlybars.compile(<<-HBS)
+          {{> global_helper_partial title="test"}}
+        HBS
+
+        expect(eval(template)).to resemble("testtest")
+      end
+    end
+
+    it "passes `this` from #each to a partial" do
+      template = Curlybars.compile(<<-HBS)
+        {{#each two_elements}}{{> user_card user=this}}{{/each}}
+      HBS
+
+      expect(eval(template)).to resemble("<span>Libo</span><span>Libo</span>")
+    end
+
+    it "passes parent scope value via ../ inside #with" do
+      template = Curlybars.compile(<<-HBS)
+        {{#with user}}{{> card title=../article.title}}{{/with}}
+      HBS
+
+      expect(eval(template)).to resemble('<div class="card">The Prince</div>')
+    end
+
+    it "passes parent scope value via ../ inside #each" do
+      template = Curlybars.compile(<<-HBS)
+        {{#each two_elements}}{{> simple_name name=../article.title}}{{/each}}
+      HBS
+
+      expect(eval(template)).to resemble("The PrinceThe Prince")
+    end
+
+    it "propagates output_too_long error from partial" do
+      Curlybars.configuration.output_limit = 50
+
+      template = Curlybars.compile(<<-HBS)
+        {{> big_output}}
+      HBS
+
+      expect { eval(template) }.to raise_error(Curlybars::Error::Render).with_message(/too long/)
+    ensure
+      Curlybars.reset
+    end
+
+    it "returns empty string for self-referencing partial (no infinite loop)" do
+      template = Curlybars.compile(<<-HBS)
+        {{> self_ref}}
+      HBS
+
+      expect(eval(template)).to resemble("")
+    end
+
+    it "renders the same partial multiple times with different options" do
+      template = Curlybars.compile(<<-HBS)
+        {{> card title="A"}}{{> card title="B"}}
+      HBS
+
+      expect(eval(template)).to resemble('<div class="card">A</div><div class="card">B</div>')
+    end
+
+    it "renders a partial inside #if" do
+      template = Curlybars.compile(<<-HBS)
+        {{#if valid}}{{> card title="yes"}}{{/if}}
+      HBS
+
+      expect(eval(template)).to resemble('<div class="card">yes</div>')
+    end
+
+    it "does not render a partial inside #unless when truthy" do
+      template = Curlybars.compile(<<-HBS)
+        {{#unless valid}}{{> card title="no"}}{{/unless}}
+      HBS
+
+      expect(eval(template)).to resemble("")
+    end
+
+    it "forwards string literal through nested partials" do
+      template = Curlybars.compile(<<-HBS)
+        {{> outer_card title="Hi"}}
+      HBS
+
+      expect(eval(template)).to resemble("<outer><inner>Hi</inner></outer>")
+    end
+
+    it "forwards a presenter through nested partials" do
+      template = Curlybars.compile(<<-HBS)
+        {{> outer_user user=user}}
+      HBS
+
+      expect(eval(template)).to resemble("<outer><inner>Libo</inner></outer>")
+    end
+
+    it "forwards a dotted path through nested partials" do
+      template = Curlybars.compile(<<-HBS)
+        {{> outer_author article=article}}
+      HBS
+
+      expect(eval(template)).to resemble("<outer><inner>Nicolò</inner></outer>")
+    end
+
+    it "forwards `this` through nested partials inside #with" do
+      template = Curlybars.compile(<<-HBS)
+        {{#with user}}{{> outer_user user=this}}{{/with}}
+      HBS
+
+      expect(eval(template)).to resemble("<outer><inner>Libo</inner></outer>")
+    end
+
+    it "forwards ../ through nested partials inside #each" do
+      template = Curlybars.compile(<<-HBS)
+        {{#each two_elements}}{{> outer_card title=../article.title}}{{/each}}
+      HBS
+
+      expect(eval(template)).to resemble(
+        "<outer><inner>The Prince</inner></outer><outer><inner>The Prince</inner></outer>"
+      )
+    end
+  end
+
   describe "#validate" do
-    it "validates the path with errors" do
+    it "does not raise errors for any partial path (lenient validation)" do
       dependency_tree = {}
 
       source = <<-HBS
-        {{> unallowed_partial}}
+        {{> unknown_partial}}
       HBS
 
       errors = Curlybars.validate(dependency_tree, source)
 
-      expect(errors).not_to be_empty
+      expect(errors).to be_empty
     end
 
-    it "raises when using a helper as a partial" do
-      dependency_tree = { helper: nil }
+    it "validates options" do
+      dependency_tree = { partial: :partial }
 
       source = <<-HBS
-        {{> helper}}
+        {{> partial title="Hello"}}
       HBS
 
       errors = Curlybars.validate(dependency_tree, source)
 
-      expect(errors).not_to be_empty
+      expect(errors).to be_empty
     end
 
-    it "does not raise with a valid partial" do
+    it "allows a presenter (Hash) as an option value" do
+      dependency_tree = { user: { first_name: nil } }
+
+      source = <<-HBS
+        {{> avatar user=user}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors).to be_empty
+    end
+
+    it "reports a single error when only one option path is out of scope" do
+      dependency_tree = { user: { first_name: nil } }
+
+      source = <<-HBS
+        {{> avatar user=user foo=nonexistent_xyzzy}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors.length).to eq(1)
+    end
+
+    it "identifies the out-of-scope path in the error message" do
+      dependency_tree = { user: { first_name: nil } }
+
+      source = <<-HBS
+        {{> avatar user=user foo=nonexistent_xyzzy}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source)
+
+      expect(errors.first.message).to match(/nonexistent_xyzzy/)
+    end
+  end
+
+  describe "#validate with resolver" do
+    let(:resolver) do
+      lambda { |name|
+        {
+          'card' => '<div class="card">{{title}}</div>',
+          'user_card' => '<span>{{user.first_name}}</span>',
+          'nested_outer' => '{{> nested_inner title="hi"}}',
+          'nested_inner' => '{{title}}',
+          'deeply_nested' => '{{> deeply_nested}}',
+          'missing_ref' => '{{subtitle}}'
+        }[name]
+      }
+    end
+
+    it "reports no errors when partial options match partial content" do
+      dependency_tree = {}
+
+      source = <<-HBS
+        {{> card title="Hello"}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source, partial_resolver: resolver)
+
+      expect(errors).to be_empty
+    end
+
+    it "reports an error when the partial references data it does not receive", :aggregate_failures do
+      dependency_tree = {}
+
+      source = <<-HBS
+        {{> missing_ref}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source, partial_resolver: resolver)
+
+      expect(errors.length).to eq(1)
+      expect(errors.first.message).to match(/subtitle/)
+    end
+
+    it "sets position.file_name to the partial identifier on partial errors", :aggregate_failures do
+      dependency_tree = {}
+
+      source = <<-HBS
+        {{> missing_ref}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source, partial_resolver: resolver)
+
+      expect(errors.length).to eq(1)
+      expect(errors.first.position.file_name).to eq(:'partials/missing_ref')
+    end
+
+    it "validates nested paths when a presenter is passed as an option" do
+      dependency_tree = { user: { first_name: nil } }
+
+      source = <<-HBS
+        {{> user_card user=user}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source, partial_resolver: resolver)
+
+      expect(errors).to be_empty
+    end
+
+    it "validates nested partials recursively" do
+      dependency_tree = {}
+
+      source = <<-HBS
+        {{> nested_outer}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source, partial_resolver: resolver)
+
+      expect(errors).to be_empty
+    end
+
+    it "prevents infinite recursion via depth limit" do
+      Curlybars.configuration.partial_nesting_limit = 3
+
+      dependency_tree = {}
+
+      source = <<-HBS
+        {{> deeply_nested}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source, partial_resolver: resolver)
+
+      expect(errors).to be_empty
+    ensure
+      Curlybars.reset
+    end
+
+    it "falls back to presenter-based partial check when resolver returns nil" do
       dependency_tree = { partial: :partial }
 
       source = <<-HBS
         {{> partial}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source, partial_resolver: resolver)
+
+      expect(errors).to be_empty
+    end
+
+    it "reports an error when resolver returns nil and path is not a partial in the tree", :aggregate_failures do
+      dependency_tree = { user: { first_name: nil } }
+
+      source = <<-HBS
+        {{> unknown_partial}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source, partial_resolver: resolver)
+
+      expect(errors.length).to eq(1)
+      expect(errors.first.message).to match(/partial/)
+    end
+
+    it "validates ../ in partial options inside #with" do
+      dependency_tree = { user: { first_name: nil }, article: { title: nil } }
+
+      source = <<-HBS
+        {{#with user}}{{> card title=../article.title}}{{/with}}
+      HBS
+
+      resolver_with_card = lambda { |name|
+        { 'card' => '<div class="card">{{title}}</div>' }[name]
+      }
+
+      errors = Curlybars.validate(dependency_tree, source, partial_resolver: resolver_with_card)
+
+      expect(errors).to be_empty
+    end
+
+    it "validates `this` in partial options inside #each" do
+      dependency_tree = { articles: [{ title: nil }] }
+
+      source = <<-HBS
+        {{#each articles}}{{> card title=this.title}}{{/each}}
+      HBS
+
+      resolver_with_card = lambda { |name|
+        { 'card' => '<div class="card">{{title}}</div>' }[name]
+      }
+
+      errors = Curlybars.validate(dependency_tree, source, partial_resolver: resolver_with_card)
+
+      expect(errors).to be_empty
+    end
+
+    it "is lenient when no resolver is provided (existing behavior)" do
+      dependency_tree = {}
+
+      source = <<-HBS
+        {{> unknown_partial}}
       HBS
 
       errors = Curlybars.validate(dependency_tree, source)

--- a/spec/integration/node/path_spec.rb
+++ b/spec/integration/node/path_spec.rb
@@ -1,5 +1,6 @@
 describe "{{path}}" do
   let(:global_helpers_providers) { [] }
+  let(:partial_provider) { nil }
 
   describe "#compile" do
     let(:post) { double("post") }

--- a/spec/integration/node/sub_expression_spec.rb
+++ b/spec/integration/node/sub_expression_spec.rb
@@ -1,5 +1,6 @@
 describe "{{(helper arg1 arg2 ... key=value ...)}}" do
   let(:global_helpers_providers) { [IntegrationTest::GlobalHelperProvider.new] }
+  let(:partial_provider) { nil }
 
   describe "#compile" do
     let(:presenter) { IntegrationTest::Presenter.new(double("view_context")) }

--- a/spec/integration/node/template_spec.rb
+++ b/spec/integration/node/template_spec.rb
@@ -1,5 +1,6 @@
 describe "template" do
   let(:global_helpers_providers) { [] }
+  let(:partial_provider) { nil }
 
   describe "#compile" do
     let(:post) { double("post") }

--- a/spec/integration/node/unless_else_spec.rb
+++ b/spec/integration/node/unless_else_spec.rb
@@ -1,5 +1,6 @@
 describe "{{#unless}}...{{else}}...{{/unless}}" do
   let(:global_helpers_providers) { [] }
+  let(:partial_provider) { nil }
 
   describe "#compile" do
     let(:post) { double("post") }

--- a/spec/integration/node/unless_spec.rb
+++ b/spec/integration/node/unless_spec.rb
@@ -1,5 +1,6 @@
 describe "{{#unless}}...{{/unless}}" do
   let(:global_helpers_providers) { [] }
+  let(:partial_provider) { nil }
 
   describe "#compile" do
     let(:post) { double("post") }

--- a/spec/integration/node/with_spec.rb
+++ b/spec/integration/node/with_spec.rb
@@ -1,5 +1,6 @@
 describe "{{#with presenter}}...{{/with}}" do
   let(:global_helpers_providers) { [IntegrationTest::GlobalHelperProvider.new] }
+  let(:partial_provider) { nil }
 
   describe "#compile" do
     let(:post) { double("post") }

--- a/spec/integration/processor/tilde_spec.rb
+++ b/spec/integration/processor/tilde_spec.rb
@@ -1,5 +1,6 @@
 describe "tilde operator" do
   let(:global_helpers_providers) { [] }
+  let(:partial_provider) { nil }
 
   describe "compilation" do
     let(:post) { double("post") }

--- a/spec/integration/spec_helper.rb
+++ b/spec/integration/spec_helper.rb
@@ -170,6 +170,39 @@ module IntegrationTest
     end
   end
 
+  class PartialResolvingProvider
+    extend Curlybars::MethodWhitelist
+
+    PARTIALS = {
+      'card' => '<div class="card">{{title}}</div>',
+      'nested_outer' => '{{> nested_inner}}',
+      'nested_inner' => 'inner',
+      'deeply_nested' => '{{> deeply_nested}}',
+      'user_card' => '<span>{{user.first_name}}</span>',
+      'article_section' => '<article>{{article.title}} by {{article.author.first_name}}</article>',
+      'comment_item' => '<li>{{comment.first_name}}</li>',
+      'simple_name' => '{{name}}',
+      'malformed' => '{{#if}}',
+      'missing_ref' => '{{missing.field}}',
+      'self_ref' => '{{> self_ref}}',
+      'global_helper_partial' => '{{foo title}}',
+      'inner_card' => '<inner>{{title}}</inner>',
+      'inner_user' => '<inner>{{user.first_name}}</inner>',
+      'inner_author' => '<inner>{{author.first_name}}</inner>',
+      'outer_card' => '<outer>{{> inner_card title=title}}</outer>',
+      'outer_user' => '<outer>{{> inner_user user=user}}</outer>',
+      'outer_author' => '<outer>{{> inner_author author=article.author}}</outer>',
+      'big_output' => "<div>#{'x' * 200}</div>"
+    }.freeze
+
+    def initialize(context = nil)
+    end
+
+    def resolve_partial(name)
+      PARTIALS[name.to_s]
+    end
+  end
+
   class GlobalHelperProvider
     extend Curlybars::MethodWhitelist
     include ActionView::Helpers::OutputSafetyHelper


### PR DESCRIPTION
Introduces a `resolve_partial(name)` protocol on global helper providers, allowing partials to be resolved from template source strings at runtime rather than only through presenter methods. Providers return raw HBS source that goes through the full curlybars pipeline (lexer → parser → AST → codegen) before execution, inheriting all existing sandboxing guarantees.

### Partial options

Partials can now receive options (`{{> card title="Hi" user=user}}`):

- String literals, presenter objects, dotted paths, `this`, and `../` parent scope references
- A new `PartialPresenter` wraps passed options and exposes only those keys through `allows_method?`, preserving the allow-methods gate

### Safety

- **Nesting limit** — configurable `partial_nesting_limit` (default 3) prevents infinite self-referencing partials; silently returns empty string when exceeded
- **Timeout** — child partials inherit the parent's `start_time`, so `rendering_timeout` applies to the entire render tree
- **Output cap** — `output_too_long` errors bubble up through nested partials
- **Error isolation** — render errors within a partial return empty string rather than crashing the host template (only timeout and output-too-long are re-raised)
- **Type check** — `resolve_partial` return value must be a String

### Backwards compatibility

When no provider resolves a name, the engine falls back to the existing presenter-method partial lookup — fully backwards-compatible.

### Validation

When a `partial_resolver` is supplied to `Curlybars.validate`, resolved partials are recursively validated against the options tree with depth-limited recursion matching the runtime guard. The `context:` keyword is now threaded through all AST node `validate` methods, and the visitor traverses partial options.

### Test plan

- Partial usage test coverage in `spec/integration/node/partial_spec.rb`
- `PartialPresenter` unit specs in `spec/curlybars/partial_presenter_spec.rb`
- All existing integration specs updated with new spec helper