### PR TITLE
Include gem version in compile cache key

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    curlybars (1.16.0.pre)
+    curlybars (1.16.1.pre)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       ffi
@@ -215,7 +215,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  curlybars (1.16.0.pre)
+  curlybars (1.16.1.pre)
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/gemfiles/rails7.2.gemfile.lock
+++ b/gemfiles/rails7.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.16.0.pre)
+    curlybars (1.16.1.pre)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       ffi
@@ -223,7 +223,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  curlybars (1.16.0.pre)
+  curlybars (1.16.1.pre)
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/gemfiles/rails8.0.gemfile.lock
+++ b/gemfiles/rails8.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.16.0.pre)
+    curlybars (1.16.1.pre)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       ffi
@@ -219,7 +219,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  curlybars (1.16.0.pre)
+  curlybars (1.16.1.pre)
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/gemfiles/rails8.1.gemfile.lock
+++ b/gemfiles/rails8.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.16.0.pre)
+    curlybars (1.16.1.pre)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       ffi
@@ -217,7 +217,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  curlybars (1.16.0.pre)
+  curlybars (1.16.1.pre)
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/lib/curlybars.rb
+++ b/lib/curlybars.rb
@@ -26,7 +26,7 @@ module Curlybars
     #
     # Returns a String containing the Ruby code.
     def compile(source, identifier = nil)
-      cache_key = ["Curlybars.compile", identifier, Digest::SHA256.hexdigest(source)]
+      cache_key = ["Curlybars.compile", Curlybars::VERSION, identifier, Digest::SHA256.hexdigest(source)]
 
       cache.fetch(cache_key) do
         ast(transformed_source(source), identifier, run_processors: true).compile

--- a/lib/curlybars/version.rb
+++ b/lib/curlybars/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Curlybars
-  VERSION = '1.16.0.pre'
+  VERSION = '1.16.1.pre'
 end

--- a/spec/integration/cache_spec.rb
+++ b/spec/integration/cache_spec.rb
@@ -38,6 +38,29 @@ describe "caching" do
     Curlybars.reset
   end
 
+  describe "Curlybars.compile" do
+    it "invalidates cache when gem version changes" do
+      source = "{{#each array_of_users}}{{/each}}"
+
+      compile_cache = dummy_cache.new
+      Curlybars.cache = compile_cache
+
+      Curlybars.compile(source, "test_template")
+      expect(compile_cache.reads).to eq(1)
+      expect(compile_cache.hits).to eq(0)
+
+      Curlybars.compile(source, "test_template")
+      expect(compile_cache.reads).to eq(2)
+      expect(compile_cache.hits).to eq(1)
+
+      stub_const("Curlybars::VERSION", "99.0.0")
+
+      Curlybars.compile(source, "test_template")
+      expect(compile_cache.reads).to eq(3)
+      expect(compile_cache.hits).to eq(1)
+    end
+  end
+
   describe "{{#each}}" do
     it "invokes cache if presenter responds to #cache_key" do
       template = Curlybars.compile(<<-HBS)


### PR DESCRIPTION
#### Description

- The `Curlybars.compile` cache key was `["Curlybars.compile", identifier, SHA256(source)]` — it didn't include the gem version
- Upgrading/downgrading the gem with the same template source would serve stale compiled code from cache, causing runtime errors (e.g. `NameError` on methods that only exist in the other version)
- Adds `Curlybars::VERSION` to the cache key so version changes automatically invalidate compiled template cache entries