### PR TITLE
Annotate partial validation errors with call-site position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 ### Unreleased
 
 * Reject self-referencing partials at validation time (e.g. `partials/faq` containing `{{> faq}}`)
+* Annotate partial validation errors with call-site positions via `metadata[:inclusion_chain]`
+
+### Curlybars 1.16.1.pre
+
+* Include gem version in compile cache key to prevent stale entries across upgrades
 
 ### Curlybars 1.16.0.pre
 
 * Add runtime partial resolution via providers that implement `resolve_partial(name)`, with options and object passing
+* Add standalone indentation linter for `.hbs` files
 
 ### Curlybars 1.15.0
 

--- a/lib/curlybars/node/partial.rb
+++ b/lib/curlybars/node/partial.rb
@@ -62,6 +62,15 @@ module Curlybars
               validation_context: context.increment_depth,
               run_processors: false
             )
+            inclusion_chain_entry = Curlybars::Position.new(
+              position.file_name,
+              position.line_number,
+              position.line_offset,
+              position.length
+            )
+            partial_errors.each do |e|
+              e.metadata[:inclusion_chain] = (e.metadata[:inclusion_chain] || []).push(inclusion_chain_entry)
+            end
             errors.concat(partial_errors)
           end
         else

--- a/spec/integration/node/partial_spec.rb
+++ b/spec/integration/node/partial_spec.rb
@@ -437,6 +437,60 @@ describe "{{> partial}}" do
       expect(errors.first.position.file_name).to eq(:'partials/missing_ref')
     end
 
+    it "sets metadata[:inclusion_chain] to an array with the call-site position", :aggregate_failures do
+      dependency_tree = {}
+
+      source = <<-HBS
+        {{> missing_ref}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source, :parent_template, partial_resolver: resolver)
+
+      expect(errors.length).to eq(1)
+      chain = errors.first.metadata[:inclusion_chain]
+      expect(chain).to be_an(Array)
+      expect(chain.length).to eq(1)
+      expect(chain.first).to be_a(Curlybars::Position)
+      expect(chain.first.file_name).to eq(:parent_template)
+      expect(chain.first.line_number).to eq(1)
+      expect(chain.first.line_offset).to eq(8)
+      expect(chain.first.length).to eq(17)
+    end
+
+    it "accumulates inclusion_chain through nested partials", :aggregate_failures do
+      nested_resolver = lambda { |name|
+        {
+          'outer' => '{{> inner}}',
+          'inner' => '{{subtitle}}'
+        }[name]
+      }
+
+      dependency_tree = {}
+
+      source = <<-HBS
+        {{> outer}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source, :top_template, partial_resolver: nested_resolver)
+
+      expect(errors.length).to eq(1)
+      expect(errors.first.position.file_name).to eq(:'partials/inner')
+
+      chain = errors.first.metadata[:inclusion_chain]
+      expect(chain).to be_an(Array)
+      expect(chain.length).to eq(2)
+      # innermost first: outer's call-site for {{> inner}}, then top's call-site for {{> outer}}
+      expect(chain[0].file_name).to eq(:'partials/outer')
+      expect(chain[0].line_number).to eq(1)
+      expect(chain[0].line_offset).to eq(0)
+      expect(chain[0].length).to eq(11)
+
+      expect(chain[1].file_name).to eq(:top_template)
+      expect(chain[1].line_number).to eq(1)
+      expect(chain[1].line_offset).to eq(8)
+      expect(chain[1].length).to eq(11)
+    end
+
     it "validates nested paths when a presenter is passed as an option" do
       dependency_tree = { user: { first_name: nil } }
 


### PR DESCRIPTION
#### Description

Replaces the single `metadata[:included_from]` position with a `metadata[:inclusion_chain]` array that accumulates call-site positions through nested partial validation. This lets consumers (e.g. Help Center) build full breadcrumb traces like `home_page.hbs:1:4 > partials/foo.hbs:1:0 > partials/bar.hbs:2:5`.

**Changes:**
- `Node::Partial#validate` now pushes onto `inclusion_chain` instead of overwriting `included_from`
- Added integration test for chain accumulation through nested partials
- Updated existing test to match new array structure

#### References

- Follow-up to #81
- Consumed by [help_center#33390](https://github.com/zendesk/help_center/pull/33390)