### PR TITLE
Reject self-referencing partials at validation time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Reject self-referencing partials at validation time (e.g. `partials/faq` containing `{{> faq}}`)
+
 ### Curlybars 1.16.0.pre
 
 * Add runtime partial resolution via providers that implement `resolve_partial(name)`, with options and object passing

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -474,6 +474,8 @@ Partials work naturally inside `each` blocks. Each iteration can pass loop-scope
 
 Partials can invoke other partials. For example, a `card` partial might include a `user_card` partial inside it. Curlybars tracks nesting depth to prevent infinite recursion — by default, partials can nest up to 3 levels deep (configurable via `partial_nesting_limit`). When the limit is reached, the partial renders as an empty string.
 
+A partial **cannot reference itself**. For example, a partial named `faq` that contains `{{> faq}}` will produce a validation error. Indirect cycles (e.g. `A` includes `B`, `B` includes `A`) are allowed up to the nesting depth limit.
+
 ### Error protection
 
 Runtime-resolved partials are designed to fail silently. If the partial source is malformed, an option references an undefined variable, or any other error occurs during rendering, the partial returns an empty string rather than crashing the entire template. Critical errors (timeouts and output-too-long) are still propagated so that safety limits remain enforced.

--- a/lib/curlybars/node/partial.rb
+++ b/lib/curlybars/node/partial.rb
@@ -34,6 +34,15 @@ module Curlybars
         end
 
         if partial_source
+          if position.file_name == :"partials/#{path.path}"
+            errors << Curlybars::Error::Validate.new(
+              'self_referencing_partial',
+              "'#{path.path}' cannot reference itself",
+              position
+            )
+            return errors
+          end
+
           options_tree = options.each_with_object({}) do |option, tree|
             expr = option.expression
             tree[option.key.to_sym] = if expr.respond_to?(:resolve)

--- a/spec/integration/node/partial_spec.rb
+++ b/spec/integration/node/partial_spec.rb
@@ -461,16 +461,34 @@ describe "{{> partial}}" do
       expect(errors).to be_empty
     end
 
-    it "prevents infinite recursion via depth limit" do
-      Curlybars.configuration.partial_nesting_limit = 3
-
+    it "reports an error for a self-referencing partial", :aggregate_failures do
       dependency_tree = {}
 
       source = <<-HBS
         {{> deeply_nested}}
       HBS
 
-      errors = Curlybars.validate(dependency_tree, source, partial_resolver: resolver)
+      errors = Curlybars.validate(dependency_tree, source, :parent_template, partial_resolver: resolver)
+
+      expect(errors.length).to eq(1)
+      expect(errors.first.message).to match(/deeply_nested.*cannot reference itself/)
+      expect(errors.first.position.file_name).to eq(:'partials/deeply_nested')
+    end
+
+    it "prevents infinite recursion of indirect cycles via depth limit" do
+      Curlybars.configuration.partial_nesting_limit = 3
+
+      cycle_resolver = lambda { |name|
+        { 'ping' => '{{> pong}}', 'pong' => '{{> ping}}' }[name]
+      }
+
+      dependency_tree = {}
+
+      source = <<-HBS
+        {{> ping}}
+      HBS
+
+      errors = Curlybars.validate(dependency_tree, source, partial_resolver: cycle_resolver)
 
       expect(errors).to be_empty
     ensure


### PR DESCRIPTION
#### Description

- A partial that includes itself (e.g. `partials/faq` with `{{> faq}}`) now fails validation with a clear error
- Indirect cycles (A → B → A) still handled by existing depth limit
- Updated docs and changelog