### PR TITLE
Raise validation error when partial nesting limit is reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Reject self-referencing partials at validation time (e.g. `partials/faq` containing `{{> faq}}`)
 * Annotate partial validation errors with call-site positions via `metadata[:inclusion_chain]`
 * Raise `validate.partial_not_found` when a partial resolver is configured but the partial cannot be found
+* Raise `validate.partial_nesting_limit_reached` error when partial nesting depth exceeds the configured limit
 
 ### Curlybars 1.16.1.pre
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,7 +81,7 @@ If not set, runtime partial resolution is disabled and only presenter-based part
 
 ## `partial_nesting_limit` (default `3`)
 
-Runtime-resolved partials can invoke other partials, creating nested rendering. To prevent infinite recursion, Curlybars limits the nesting depth. When the limit is reached, the partial renders as an empty string.
+Runtime-resolved partials can invoke other partials, creating nested rendering. To prevent infinite recursion, Curlybars limits the nesting depth. When the limit is reached at runtime, the partial renders as an empty string. If the limit is exceeded during validation, a `Curlybars::Error::Validate` with id `validate.partial_nesting_limit_reached` is raised instead.
 
 ```ruby
 Curlybars.configure do |config|

--- a/lib/curlybars/node/partial.rb
+++ b/lib/curlybars/node/partial.rb
@@ -72,6 +72,12 @@ module Curlybars
               e.metadata[:inclusion_chain] = (e.metadata[:inclusion_chain] || []).push(inclusion_chain_entry)
             end
             errors.concat(partial_errors)
+          else
+            errors << Curlybars::Error::Validate.new(
+              'partial_nesting_limit_reached',
+              "'#{path.path}' exceeds the partial nesting limit of #{Curlybars.configuration.partial_nesting_limit}",
+              position
+            )
           end
         else
           path_errors = Array(path.validate(branches, check_type: :partial))

--- a/spec/integration/node/partial_spec.rb
+++ b/spec/integration/node/partial_spec.rb
@@ -529,7 +529,7 @@ describe "{{> partial}}" do
       expect(errors.first.position.file_name).to eq(:'partials/deeply_nested')
     end
 
-    it "prevents infinite recursion of indirect cycles via depth limit" do
+    it "reports an error when infinite recursion is detected via depth limit", :aggregate_failures do
       Curlybars.configuration.partial_nesting_limit = 3
 
       cycle_resolver = lambda { |name|
@@ -544,7 +544,8 @@ describe "{{> partial}}" do
 
       errors = Curlybars.validate(dependency_tree, source, partial_resolver: cycle_resolver)
 
-      expect(errors).to be_empty
+      expect(errors).not_to be_empty
+      expect(errors.last.id).to eq('validate.partial_nesting_limit_reached')
     ensure
       Curlybars.reset
     end


### PR DESCRIPTION
#### Description

- Instead of silently stopping validation when partial nesting depth exceeds the configured limit, raise a `Curlybars::Error::Validate` with id `validate.partial_nesting_limit_reached`
- Updated docs to document the new validation behavior