### PR TITLE
Raise partial_not_found when resolver exists but partial is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Reject self-referencing partials at validation time (e.g. `partials/faq` containing `{{> faq}}`)
 * Annotate partial validation errors with call-site positions via `metadata[:inclusion_chain]`
+* Raise `validate.partial_not_found` when a partial resolver is configured but the partial cannot be found
 
 ### Curlybars 1.16.1.pre
 

--- a/lib/curlybars/node/partial.rb
+++ b/lib/curlybars/node/partial.rb
@@ -74,7 +74,16 @@ module Curlybars
             errors.concat(partial_errors)
           end
         else
-          errors.concat(Array(path.validate(branches, check_type: :partial)))
+          path_errors = Array(path.validate(branches, check_type: :partial))
+          if path_errors.any? && context&.partial_resolver
+            errors << Curlybars::Error::Validate.new(
+              'partial_not_found',
+              "'#{path.path}' partial could not be found",
+              position
+            )
+          else
+            errors.concat(path_errors)
+          end
         end
 
         errors

--- a/spec/integration/node/partial_spec.rb
+++ b/spec/integration/node/partial_spec.rb
@@ -561,7 +561,7 @@ describe "{{> partial}}" do
       expect(errors).to be_empty
     end
 
-    it "reports an error when resolver returns nil and path is not a partial in the tree", :aggregate_failures do
+    it "reports a partial_not_found error when resolver returns nil and path is not in the tree", :aggregate_failures do
       dependency_tree = { user: { first_name: nil } }
 
       source = <<-HBS
@@ -571,7 +571,8 @@ describe "{{> partial}}" do
       errors = Curlybars.validate(dependency_tree, source, partial_resolver: resolver)
 
       expect(errors.length).to eq(1)
-      expect(errors.first.message).to match(/partial/)
+      expect(errors.first.id).to eq('validate.partial_not_found')
+      expect(errors.first.message).to match(/unknown_partial.*could not be found/)
     end
 
     it "validates ../ in partial options inside #with" do


### PR DESCRIPTION
#### Description

- When a `partial_resolver` is configured but returns nil and the path also fails presenter-based validation, raise a specific `validate.partial_not_found` error instead of the generic `not_a_partial`
- Preserves backward compat: presenter-defined partials still work (no error if presenter check passes)