### PR TITLE
Release curlybars 1.16.1.pre.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Unreleased
 
-### Curlybars 1.16.2.pre
+### Curlybars 1.16.1.pre.2
 
 * Reject self-referencing partials at validation time (e.g. `partials/faq` containing `{{> faq}}`)
 * Annotate partial validation errors with call-site positions via `metadata[:inclusion_chain]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+### Curlybars 1.16.2.pre
+
 * Reject self-referencing partials at validation time (e.g. `partials/faq` containing `{{> faq}}`)
 * Annotate partial validation errors with call-site positions via `metadata[:inclusion_chain]`
 * Raise `validate.partial_not_found` when a partial resolver is configured but the partial cannot be found

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    curlybars (1.16.1.pre)
+    curlybars (1.16.2.pre)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       ffi
@@ -215,7 +215,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  curlybars (1.16.1.pre)
+  curlybars (1.16.2.pre)
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    curlybars (1.16.2.pre)
+    curlybars (1.16.1.pre.2)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       ffi
@@ -215,7 +215,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  curlybars (1.16.2.pre)
+  curlybars (1.16.1.pre.2)
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -264,6 +264,44 @@ end
 {{name 'argument' option='value'}}
 ```
 
+### Id `validate.self_referencing_partial`
+
+This exception occurs when a partial references itself, which would cause infinite recursion.
+
+```hbs
+{{! assuming this template is partials/faq }}
+
+{{! this will raise the exception }}
+
+{{> faq}}
+```
+
+### Id `validate.partial_not_found`
+
+This exception occurs when a partial resolver is configured but the referenced partial cannot be found.
+
+```hbs
+{{! this will raise the exception if 'missing_partial' does not exist }}
+
+{{> missing_partial}}
+```
+
+### Id `validate.partial_nesting_limit_reached`
+
+This exception occurs when partial nesting depth exceeds the configured `partial_nesting_limit` (default `3`). See [configuration](configuration.md) for details.
+
+```hbs
+{{! assuming partial_nesting_limit is 2 }}
+
+{{! in partial_a: }}
+{{> partial_b}}
+
+{{! in partial_b: }}
+{{> partial_c}}
+
+{{! partial_c will trigger the exception }}
+```
+
 ### Id `validate.unallowed_path`
 
 This exception occurs when a path is not allowed, given the allowed method definition

--- a/gemfiles/rails7.2.gemfile.lock
+++ b/gemfiles/rails7.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.16.2.pre)
+    curlybars (1.16.1.pre.2)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       ffi
@@ -223,7 +223,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  curlybars (1.16.2.pre)
+  curlybars (1.16.1.pre.2)
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/gemfiles/rails7.2.gemfile.lock
+++ b/gemfiles/rails7.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.16.1.pre)
+    curlybars (1.16.2.pre)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       ffi
@@ -223,7 +223,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  curlybars (1.16.1.pre)
+  curlybars (1.16.2.pre)
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/gemfiles/rails8.0.gemfile.lock
+++ b/gemfiles/rails8.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.16.1.pre)
+    curlybars (1.16.2.pre)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       ffi
@@ -219,7 +219,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  curlybars (1.16.1.pre)
+  curlybars (1.16.2.pre)
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/gemfiles/rails8.0.gemfile.lock
+++ b/gemfiles/rails8.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.16.2.pre)
+    curlybars (1.16.1.pre.2)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       ffi
@@ -219,7 +219,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  curlybars (1.16.2.pre)
+  curlybars (1.16.1.pre.2)
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/gemfiles/rails8.1.gemfile.lock
+++ b/gemfiles/rails8.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.16.2.pre)
+    curlybars (1.16.1.pre.2)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       ffi
@@ -217,7 +217,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  curlybars (1.16.2.pre)
+  curlybars (1.16.1.pre.2)
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/gemfiles/rails8.1.gemfile.lock
+++ b/gemfiles/rails8.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    curlybars (1.16.1.pre)
+    curlybars (1.16.2.pre)
       actionpack (>= 7.2)
       activesupport (>= 7.2)
       ffi
@@ -217,7 +217,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  curlybars (1.16.1.pre)
+  curlybars (1.16.2.pre)
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373

--- a/lib/curlybars/version.rb
+++ b/lib/curlybars/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Curlybars
-  VERSION = '1.16.1.pre'
+  VERSION = '1.16.2.pre'
 end

--- a/lib/curlybars/version.rb
+++ b/lib/curlybars/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Curlybars
-  VERSION = '1.16.2.pre'
+  VERSION = '1.16.1.pre.2'
 end


### PR DESCRIPTION
#### Summary
- Document new partial validation errors in docs/errors.md
- Bump version to 1.16.2.pre
- Move unreleased changelog entries under new version section

#### Changes since 1.16.1.pre
* Reject self-referencing partials at validation time
* Annotate partial validation errors with call-site positions via `metadata[:inclusion_chain]`
* Raise `validate.partial_not_found` when a partial resolver is configured but the partial cannot be found
* Raise `validate.partial_nesting_limit_reached` error when partial nesting depth exceeds the configured limit