### PR TITLE
Add AI-ready documentation (AGENTS.md, ARCHITECTURE.md, SECURITY.md)

### DIFF
--- a/.cursor/rules/00-core.mdc
+++ b/.cursor/rules/00-core.mdc
@@ -1,0 +1,9 @@
+---
+description: Core project conventions
+globs: ["**/*"]
+alwaysApply: true
+---
+
+Read and follow all instructions in the root `AGENTS.md` file.
+Read and follow all security requirements in `SECURITY.md`.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+# Copilot Instructions
+
+Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
+Read and follow all instructions in `SECURITY.md` — mandatory security requirements.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,3 @@
+Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
+Read and follow all instructions in `SECURITY.md` — mandatory security requirements.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,105 @@
+# Curlybars
+
+Curlybars is a Ruby gem implementing a subset of the Handlebars templating language for Rails applications. It uses a presenter pattern (inspired by the Curly gem) to provide type-safe, whitelisted context to templates. Templates use `.hbs` extensions and are validated at development time before rendering.
+
+## Setup & Commands
+
+```bash
+# Install dependencies
+bundle install
+
+# Run all tests
+bundle exec rspec
+
+# Run a single test file
+bundle exec rspec spec/curlybars/lexer_spec.rb
+
+# Run linter
+bundle exec rubocop
+
+# Run both tests and linting (default task)
+bundle exec rake
+
+# Run tests against a specific Rails gemfile
+BUNDLE_GEMFILE=gemfiles/rails8.1.gemfile bundle exec rspec
+```
+
+## Code Conventions
+
+- Follow RuboCop rules configured in `.rubocop.yml` (plugins: performance, rake, rspec, rspec_rails)
+- Use `frozen_string_literal: true` magic comment at the top of files
+- Error classes inherit from `Curlybars::Error::Base` and live in `lib/curlybars/error/`
+- AST node classes live in `lib/curlybars/node/`; each node responds to `.compile` and `.validate`
+- New node types must be registered in `lib/curlybars/parser.rb` and required in `lib/curlybars.rb`
+- Processors implement `.process!(tokens, identifier)` and live in `lib/curlybars/processor/`
+- Use `extend Curlybars::MethodWhitelist` (not inheritance) for PORO presenters; subclass `Curlybars::Presenter` only for root presenters
+- Configuration keys are added to `Curlybars::Configuration` with accessor and a sensible default in `#initialize`
+
+## Testing
+
+- Framework: RSpec (see `spec/spec_helper.rb`)
+- `spec/curlybars/` — unit tests mirroring `lib/curlybars/`
+- `spec/acceptance/` — acceptance tests for template features (use integration helpers)
+- `spec/integration/` — integration tests using the Rails dummy app at `spec/dummy/`
+- `spec/matchers/` — custom RSpec matchers shared across suites
+- Always add tests covering the `compile`, `validate`, and `render` phases for new language features
+- Use `bundle exec rspec spec/path/to_spec.rb` to run a focused test
+
+## Do
+
+- Use `allow_methods` to explicitly whitelist methods on presenters — this is a security boundary
+- Add both positive and negative test cases when implementing new node types or error conditions
+- Use `Curlybars::Error::Base` subclasses with a unique `id` string for all error types
+- Use `ActiveSupport::Notifications` instruments (`compile.curlybars`) for observability
+- Configure runtime limits (`output_limit`, `rendering_timeout`) in the Rails initializer
+- Register new template language features (nodes, processors) via the configuration extension points
+- Use `Curlybars::Generic` as the return type annotation for helpers whose output type is dynamic
+
+## Don't
+
+- Don't expose presenter methods without explicitly whitelisting them via `allow_methods` — the whitelist is a security control
+- Don't call `Curlybars::Lexer`, `Curlybars::Parser`, or AST node internals directly from application code — use the `Curlybars.compile`, `Curlybars.validate`, and `Curlybars.visit` public API
+- Don't add arbitrary Ruby evaluation or metaprogramming that could bypass the method whitelist
+- Don't modify `Gemfile.lock` directly — run `bundle install`; update per-Rails gemfile locks in `gemfiles/`
+- Don't hardcode Rails or Ruby version constraints in new code — check `curlybars.gemspec` and `gemfiles/` for the tested matrix
+- Don't use `eval` or `exec` with user-supplied template content outside the controlled compilation pipeline
+
+## Architecture
+
+See `ARCHITECTURE.md` for component map, compilation pipeline, and design decisions.
+
+## Security
+
+See `SECURITY.md` for mandatory security requirements, prohibited patterns, and escalation triggers.
+
+## Safety & Permissions
+
+Allowed without approval:
+- Read/list files
+- Run single-file tests (`bundle exec rspec spec/path/to_spec.rb`)
+- Run RuboCop on specific files
+
+Ask before:
+- Installing or removing gems (modifying `Gemfile` or `curlybars.gemspec`)
+- Deleting files or directories
+- Running the full test matrix across all gemfiles
+- Modifying CI/CD workflows in `.github/workflows/`
+- Pushing to remote branches or updating `lib/curlybars/version.rb` (triggers a publish)
+
+## PR & Commit Guidelines
+
+- PR titles: plain English, imperative mood (e.g., "Add support for inline partials")
+- Commit messages: short summary (50 chars max), blank line, then longer description if needed
+- No ticket number format required; see CONTRIBUTING.md for full guidelines
+- Releasing: update `lib/curlybars/version.rb` and `CHANGELOG.md`, update all `gemfiles/*.lock` files, then merge to `main` — the publish workflow fires automatically
+
+## References
+
+- Architecture: `ARCHITECTURE.md`
+- Security: `SECURITY.md`
+- Contributing: `CONTRIBUTING.md`
+- Template language spec: `docs/templates.md`
+- Presenter documentation: `docs/presenters.md`
+- Helpers documentation: `docs/helpers.md`
+- Configuration options: `docs/configuration.md`
+- Error reference: `docs/errors.md`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,102 @@
+# Curlybars — Architecture
+
+## System Overview
+
+Curlybars is a Rails-integrated Ruby gem that compiles Handlebars-flavored `.hbs` templates into Ruby code at request time. Templates are validated against a presenter's declared method whitelist before rendering, providing a security boundary between template authors and the Ruby runtime. The gem integrates into Rails via a Railtie that registers the `.hbs` template handler and a dependency tracker for the asset pipeline.
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    HBS["*.hbs template\n(source string)"] --> Transformers["Compiler Transformers\n(config.compiler_transformers)"]
+    Transformers --> Lexer["Lexer\n(RLTK-based tokenizer)"]
+    Lexer --> TildeProc["Processor::Tilde\n(whitespace stripping)"]
+    TildeProc --> CustomProc["Custom Processors\n(config.custom_processors)"]
+    CustomProc --> Parser["Parser\n(RLTK-based, builds AST)"]
+    Parser --> AST["AST\n(Node::Root → Node::Template → items)"]
+    AST -->|"#validate"| Validator["Validation\nPresenter dependency tree"]
+    AST -->|"#compile"| Compiler["Compiled Ruby string"]
+    Compiler --> Rails["Rails eval / SafeBuffer output"]
+
+    RailsReq["Rails request"] --> Handler["TemplateHandler\n(ActionView integration)"]
+    Handler --> Curlybars["Curlybars.compile / .validate"]
+    Handler --> Presenter["Root Presenter\n(subclass of Curlybars::Presenter)"]
+    Presenter --> PORO["PORO Presenters\n(extend MethodWhitelist)"]
+```
+
+## Component Map
+
+| Path | Responsibility |
+|------|---------------|
+| `lib/curlybars.rb` | Public API: `compile`, `validate`, `valid?`, `visit`, `find`; bootstraps pipeline |
+| `lib/curlybars/lexer.rb` | Tokenizes HBS source using RLTK; state machine for `{{`, `}}`, comments, tilde |
+| `lib/curlybars/parser.rb` | Builds AST from token stream using RLTK grammar productions |
+| `lib/curlybars/node/` | One file per AST node type; each node implements `#compile` and `#validate` |
+| `lib/curlybars/processor/` | Token-level transforms before parsing (`Tilde`, custom processors) |
+| `lib/curlybars/rendering_support.rb` | Runtime helper: context stack, variable resolution, timeout enforcement, caching |
+| `lib/curlybars/template_handler.rb` | Rails `ActionView::Template` handler; resolves presenter, calls `compile`, wraps in cache |
+| `lib/curlybars/presenter.rb` | Base class for root presenters; handles `presents`, caching keys, setup lifecycle |
+| `lib/curlybars/method_whitelist.rb` | Module providing `allow_methods` DSL; generates `dependency_tree` for validation |
+| `lib/curlybars/generic.rb` | Marker type for dynamically-typed helper return values |
+| `lib/curlybars/partial_presenter.rb` | Presenter wrapper for `{{> partial}}` resolution |
+| `lib/curlybars/path_finder.rb` | AST walker for finding path nodes by target path and syntactic role |
+| `lib/curlybars/visitor.rb` | Base visitor class for AST traversal |
+| `lib/curlybars/configuration.rb` | Runtime configuration: limits, processors, global helpers, cache, partial provider |
+| `lib/curlybars/railtie.rb` | Rails integration: registers `.hbs` handler and dependency tracker |
+| `lib/curlybars/error/` | Error hierarchy rooted at `Error::Base`; typed errors for lex/parse/compile/validate/render |
+| `lib/curlybars/validation_context.rb` | Carries partial resolver and call-site metadata during validation |
+| `spec/curlybars/` | Unit tests mirroring `lib/curlybars/` |
+| `spec/acceptance/` | Acceptance tests for template language features |
+| `spec/integration/` | Full-stack integration tests using the `spec/dummy/` Rails app |
+| `docs/` | User-facing documentation (templates, presenters, helpers, configuration, errors) |
+| `gemfiles/` | Per-Rails-version Bundler gemfiles for CI matrix (`rails7.2`, `rails8.0`, `rails8.1`, `rails_main`) |
+
+## Compilation Pipeline
+
+1. **Transformer pass** — `config.compiler_transformers` rewrite the raw HBS source string before tokenization
+2. **Lexer** — `Curlybars::Lexer` tokenizes the source (RLTK state machine; handles comments, tilde whitespace control, variables `@var`, paths, literals)
+3. **Token processors** — `Processor::Tilde` strips adjacent whitespace tokens; custom processors from `config.custom_processors` run in order
+4. **Parser** — `Curlybars::Parser` (RLTK grammar) produces an AST rooted at `Node::Root`
+5. **Validate** — `ast.validate(branches, context:)` walks the tree against the presenter's `dependency_tree`; returns an array of `Error::Validate` (empty = valid)
+6. **Compile** — `ast.compile` emits a Ruby string; `Curlybars.compile` caches the result keyed by `[VERSION, identifier, SHA256(source)]`
+7. **Render** — the compiled Ruby string is `eval`'d inside the ActionView context, writing to `@output_buffer` via `RenderingSupport`
+
+## Key Design Decisions
+
+### Presenter Method Whitelist as Security Boundary
+Templates can only access methods explicitly declared via `allow_methods`. This prevents template authors from calling arbitrary Ruby. The whitelist also drives the `dependency_tree` used for static validation, so security and correctness share one source of truth.
+
+### Two-Phase Operation: Validate then Compile
+Curlybars separates validation (checking template correctness against a presenter schema) from compilation (generating Ruby). Validation can be run at deploy-time or in tests without executing the template.
+
+### RLTK-Based Lexer and Parser
+The lexer and parser use the RLTK gem for formal grammar definitions. This makes the language specification explicit and maintainable rather than ad-hoc regex.
+
+### Rails Railtie Integration
+The gem auto-registers itself with Rails by loading `Curlybars::Railtie` when `Rails` is defined. No manual setup is required beyond adding the gem to the `Gemfile`.
+
+### Compilation Caching
+`Curlybars.compile` caches compiled Ruby code in `Rails.cache` (set by the Railtie) keyed by gem version, template identifier, and source hash. This avoids re-parsing on every request.
+
+### Runtime Safety Limits
+`RenderingSupport` enforces `rendering_timeout` and the `output_limit` is checked during rendering. These prevent runaway templates from consuming unbounded resources.
+
+## External Dependencies
+
+| Dependency | Purpose | Declared In |
+|------------|---------|-------------|
+| `rltk` | Lexer and parser framework | `curlybars.gemspec` |
+| `actionpack` / `activesupport` | Rails integration, SafeBuffer, notifications | `curlybars.gemspec` |
+| `ffi` | Required by rltk for native extensions | `curlybars.gemspec` |
+| RubyGems.org | Distribution channel | Released via `publish.yml` workflow |
+
+## Cross-Cutting Concerns
+
+### Configuration
+Access via `Curlybars.configure { |c| c.option = value }` in a Rails initializer. See `docs/configuration.md` for all options.
+
+### Observability
+Template compilation fires `ActiveSupport::Notifications` `compile.curlybars` events with `{ path: }` payload. Subscribe in an initializer for custom metrics.
+
+### Error Handling
+All errors are subclasses of `Curlybars::Error::Base` with a typed `id` string and optional `position` (file, line, offset). Render-time errors include `timeout` and context-type errors. Lex/parse errors wrap RLTK exceptions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Code Configuration
+
+Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
+Read and follow all instructions in `SECURITY.md` — mandatory security requirements.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,194 @@
+# AI Agent Security Standard — Curlybars
+
+This document defines mandatory security principles and restrictions for all AI coding assistants operating in this repository. All AI agents must follow these requirements without exception.
+
+**Authority:** Derived from [Zendesk Minimum Baseline Security Standard](https://docs.google.com/document/d/17GZ9TpjKCt6WCdw3yxL44Ra_YscbOBVnVkUVGgx5Hz0/) and internal security policies.
+
+---
+
+## Core Security Mandate
+
+Security is a first-class requirement. Every code suggestion must be evaluated against these guidelines. If a request would result in insecure code:
+
+1. **Stop** and flag the security concern
+2. **Explain** why it's problematic
+3. **Propose** a secure alternative
+
+AI-generated code requires human review before merging.
+
+---
+
+## Absolute Prohibitions
+
+AI agents must **NEVER** do the following:
+
+### Secrets & Credentials
+- Hardcode secrets, credentials, API keys, tokens, or passwords in source code
+- Store secrets in version control (`.env` files, config with real values)
+- Log, print, or expose secret values
+- Expose credentials in URLs, logs, or error messages
+
+### Method Whitelist Bypass
+- Generate code that circumvents the `allow_methods` whitelist on presenters
+- Suggest `method_missing`, `send`, `public_send`, or `respond_to_missing?` overrides that would expose non-whitelisted methods to templates
+- Weaken or remove `allows_method?` checks in `RenderingSupport`
+- Add catch-all allowances (e.g., `allow_methods *instance_methods`) without explicit review
+
+### Unsafe Template Evaluation
+- Inject arbitrary Ruby into compiled template strings outside the controlled `Curlybars.compile` pipeline
+- Use `eval`, `instance_eval`, or `class_eval` with user-supplied template content outside the compilation pipeline (note: `Security/Eval` is excluded for `spec/integration/**/*` only as a deliberate test choice)
+- Disable the `rendering_timeout` or `output_limit` safety limits in production configuration
+
+### Security Controls
+- Disable or weaken security controls (`verify=False`, disabled auth, `ALLOW_ALL` CORS)
+- Bypass authentication or authorization checks
+- Disable certificate validation
+
+### Dangerous Code Patterns
+- Generate shell commands using raw string interpolation from user input
+- Use deprecated algorithms (MD5, SHA-1, DES, RC4, ECB mode)
+
+### Data Exposure
+- Log sensitive data (PII, credentials, tokens, customer data)
+- Expose stack traces or internal paths to end users
+- Transmit sensitive data over unencrypted channels
+
+---
+
+## Required Security Patterns
+
+### Presenter Method Whitelisting
+
+```ruby
+# Correct: Explicit whitelist — only these methods are accessible from templates
+class InvoicePresenter < Curlybars::Presenter
+  allow_methods :amount, :date, recipient: RecipientPresenter
+
+  def amount
+    @invoice.amount
+  end
+end
+```
+
+```ruby
+# NEVER: Exposing all methods or bypassing the whitelist
+class InvoicePresenter < Curlybars::Presenter
+  allow_methods *instance_methods  # exposes everything
+end
+```
+
+### Secret Management
+
+```ruby
+# Correct: Environment variables or secret manager
+api_key = ENV.fetch("MY_SERVICE_API_KEY")
+```
+
+```ruby
+# NEVER: Hardcoded secrets
+api_key = "sk-abc123XYZ"
+```
+
+### Input Validation
+
+```ruby
+# Correct: Parameterized query
+User.where(id: user_id)
+```
+
+```ruby
+# NEVER: String interpolation in queries
+User.where("id = #{user_id}")
+```
+
+### Logging
+
+```ruby
+# Correct: Structured logging without sensitive data
+Rails.logger.info("Template compiled", path: template.virtual_path)
+```
+
+```ruby
+# NEVER: Logging sensitive data
+Rails.logger.debug("Presenter data: #{presenter.as_json}")  # may contain PII
+```
+
+---
+
+## Security Requirements by Domain
+
+### Template Compilation & Execution
+- All template compilation must go through `Curlybars.compile` — do not bypass the pipeline
+- Validate templates against a presenter's `dependency_tree` before deploying to production
+- Set appropriate `rendering_timeout` and `output_limit` in Rails initializers to prevent resource exhaustion
+- Never allow templates from untrusted sources to reference non-whitelisted paths
+
+### Presenter Security
+- Every public method accessible from a template must be explicitly declared via `allow_methods`
+- Return types declared in `allow_methods` must accurately reflect the runtime types
+- Do not use `Generic` as a return type unless the method genuinely needs to return variable types — it bypasses type-level validation
+
+### Authentication & Authorization
+- Use the approved authentication system for end-user authentication
+- Apply principle of least privilege to presenter method exposure
+- Log failed authorization checks in application code that uses Curlybars presenters
+
+### Cryptography
+
+| Use Case | Approved | Forbidden |
+|----------|----------|-----------|
+| Password hashing | bcrypt, Argon2, PBKDF2 | MD5, SHA-1, unsalted hashes |
+| Integrity hashing | SHA-256, SHA-3 | MD5, SHA-1 |
+| Symmetric encryption | AES-256-GCM | DES, 3DES, AES-ECB |
+| TLS | TLS 1.2+ | SSLv2/3, TLS 1.0/1.1 |
+
+### Error Handling
+- Return typed `Curlybars::Error::*` instances — never expose raw Ruby exceptions or backtraces to end users
+- Use the `id` field on errors for programmatic handling; use `message` for human-readable display only
+- Do not include file paths or internal implementation details in error messages shown to template authors in production
+
+---
+
+## When to Stop and Escalate
+
+Stop, explain the concern, and recommend involving Security if a task requires:
+
+- Removing or weakening the `allow_methods` whitelist mechanism
+- Adding template execution without validation against a presenter schema
+- Disabling `rendering_timeout` or `output_limit` in a production context
+- Bypassing or weakening security controls
+- Exposing customer data or restricted information
+- Using deprecated cryptographic algorithms
+- Accessing production data without authorization
+- Any change to the `Security/Eval` RuboCop exclusion scope
+
+---
+
+## Security Testing
+
+When generating features, include:
+
+- Tests verifying that non-whitelisted methods raise `Curlybars::Error::Validate` or `Curlybars::Error::Render`
+- Tests confirming that `rendering_timeout` raises `Curlybars::Error::Render` with id `timeout`
+- Negative test cases for invalid template paths and unauthorized method access
+- Tests for presenter boundary enforcement (PORO presenters cannot expose unwhitelisted methods)
+
+---
+
+## Reporting Vulnerabilities
+
+If you discover a security vulnerability in Curlybars, please report it to the maintainers at `vikings@zendesk.com` or via the [Zendesk Security Engagement process](https://techmenu.zende.sk/).
+
+Do not open a public GitHub issue for security vulnerabilities.
+
+---
+
+## References
+
+- [Minimum Baseline Security Standard](https://docs.google.com/document/d/17GZ9TpjKCt6WCdw3yxL44Ra_YscbOBVnVkUVGgx5Hz0/)
+- [Cryptography Standards](https://techmenu.zende.sk/standards/cryptography-standards/)
+- [Unified JWT Standard](https://techmenu.zende.sk/standards/unified-jwt/)
+
+---
+
+**Questions?** Reach out to @zendesk/vikings or file a ticket via the Security Engagement process.


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` — vendor-neutral conventions hub covering setup commands, code conventions, testing, do/don't lists, and PR guidelines
- Adds `ARCHITECTURE.md` — Mermaid diagram of the compilation pipeline, component map, key design decisions, and external dependencies
- Adds `SECURITY.md` — AI agent security standard covering the presenter method-whitelist security model, absolute prohibitions, required patterns, and escalation triggers
- Adds thin spoke files (`CLAUDE.md`, `.github/copilot-instructions.md`, `.cursor/rules/00-core.mdc`, `.windsurfrules`) that reference the hubs

## Test plan

- [ ] Review `AGENTS.md` commands against `Rakefile` and `gemfiles/` to confirm accuracy
- [ ] Review `ARCHITECTURE.md` diagram matches `lib/curlybars/` structure
- [ ] Review `SECURITY.md` prohibitions match the presenter whitelist security model
- [ ] Verify no source code was modified (only new documentation files added)

---
Requested by @st33n via [zendesk/ai-repo#313](https://github.com/zendesk/ai-repo/issues/313)